### PR TITLE
Move gem dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
-
-rails_version = ENV["RAILS_VERSION"] || "default"
-
-case rails_version
-when "master"
-  gem "activesupport", {github: "rails/activesupport"}
-  gem "railties", {github: "rails/railties"}
-when "5.0"
-  gem "activesupport", "~> 5.0.7"
-  gem "railties", "~> 5.0.7"
-when "5.1"
-  gem "activesupport", "~> 5.1.7"
-  gem "railties", "~> 5.1.7"
-when "5.2"
-  gem "activesupport", "~> 5.2.3"
-  gem "railties", "~> 5.2.3"
-when "6.0"
-  gem "activesupport", "~> 6.0.0"
-  gem "railties", "~> 6.0.0"
-else
-  gem "activesupport", "~> 5.2.3"
-  gem "railties", "~> 5.2.3"
-end

--- a/yarr.gemspec
+++ b/yarr.gemspec
@@ -1,22 +1,24 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
-  s.name          = %q{yarr}
-  s.version       = "0.0.1"
-  s.date          = %q{2020-06-01}
-  s.summary       = %q{A Ruby ORM API for Redis}
-  s.authors       = ["Chan Zuckerberg Initiative"]
-  s.email         = "opensource@chanzuckerberg.com"
-  s.homepage      = "https://github.com/chanzuckerberg/redis-record"
+  s.name          = 'yarr'
+  s.version       = '0.0.1'
+  s.date          = '2020-06-01'
+  s.summary       = 'A Ruby ORM API for Redis'
+  s.authors       = ['Chan Zuckerberg Initiative']
+  s.email         = 'opensource@chanzuckerberg.com'
+  s.homepage      = 'https://github.com/chanzuckerberg/redis-record'
   s.license       = 'MIT'
-  s.require_paths = ["lib"]
+  s.require_paths = ['lib']
   s.files         = Dir.glob('lib/**/*')
 
   s.required_ruby_version = ['>= 2.4.0']
 
+  s.add_dependency 'activesupport', '~> 5.0.7'
+  s.add_dependency 'railties', '~> 5.0.7'
   s.add_dependency 'redis', '~> 4.0'
   s.add_dependency 'sorbet', '>= 0.4.4704'
-  s.add_dependency 'sorbet-static', '>= 0.4.4704'
   s.add_dependency 'sorbet-coerce', '0.2.7'
-
-  s.add_runtime_dependency 'sorbet-runtime', '>= 0.4.4704'
-
+  s.add_dependency 'sorbet-runtime', '>= 0.4.4704'
+  s.add_dependency 'sorbet-static', '>= 0.4.4704'
 end


### PR DESCRIPTION
### Motivation
This moves the gems from Gemfile to gemspec. activesupport and railties should belong to gemspec. If the gems are missing, `gem` will install them automatically.

### Test Plan
- [x] Create a blank project with `yarr` in the Gemfile, run `bundle install`. See the gems show up in Gemfile.lock.