### PR TITLE
Fix dependent gem versions

### DIFF
--- a/yarr.gemspec
+++ b/yarr.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ['>= 2.4.0']
 
-  s.add_dependency 'activesupport', '~> 5.0.7'
-  s.add_dependency 'railties', '~> 5.0.7'
-  s.add_dependency 'redis', '~> 4.0'
+  s.add_dependency 'activesupport', '~> 5'
+  s.add_dependency 'railties', '~> 5'
+  s.add_dependency 'redis', '~> 4'
   s.add_dependency 'sorbet', '>= 0.4.4704'
-  s.add_dependency 'sorbet-coerce', '0.2.7'
+  s.add_dependency 'sorbet-coerce', '>= 0.2.7'
   s.add_dependency 'sorbet-runtime', '>= 0.4.4704'
   s.add_dependency 'sorbet-static', '>= 0.4.4704'
 


### PR DESCRIPTION
### Motivation
https://github.com/chanzuckerberg/redis-record/pull/8#discussion_r437025521

### Test Plan
- [x] `bundle install` in a repo with Rails 5.2 installed. See no errors