### PR TITLE
Make id,created_at,updated_at indexed attributes

### DIFF
--- a/lib/redcord/base.rb
+++ b/lib/redcord/base.rb
@@ -52,8 +52,9 @@ module Redcord::Base
       # coerced to the specified attribute types. Like ActiveRecord,
       # Redcord manages the created_at and updated_at fields behind the
       # scene.
-      prop :created_at, T.nilable(Time)
-      prop :updated_at, T.nilable(Time)
+      attribute :id, T.nilable(Integer), index: true
+      attribute :created_at, T.nilable(Time), index: true
+      attribute :updated_at, T.nilable(Time), index: true
     end
   end
 end

--- a/lib/redcord/server_scripts/create_hash_returning_id.erb.lua
+++ b/lib/redcord/server_scripts/create_hash_returning_id.erb.lua
@@ -60,6 +60,7 @@ if #index_attr_keys > 0 then
   end
 end
 local range_index_attr_keys = redis.call('smembers', model .. ':range_index_attrs')
+attrs_hash['id'] = id
 if #range_index_attr_keys > 0 then
   for _, attr_key in ipairs(range_index_attr_keys) do
     add_id_to_range_index_attr(model, attr_key, attrs_hash[attr_key], id)

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -161,6 +161,11 @@ describe Redcord::Actions do
       expect(another_instance.indexed_value).to eq instance.indexed_value
 
       expect(klass.find_by(indexed_value: 0)).to be_nil
+      expect(klass.find_by(id: instance.id)).to_not be_nil
+      expect(klass.find_by(
+        id: instance.id,
+        indexed_value: instance.indexed_value,
+      )).to_not be_nil
     end
   end
 

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -41,7 +41,7 @@ describe Redcord::Attribute do
   it 'adds attributes to the classes' do
     expect(
       klass.class_variable_get(:@@range_index_attributes),
-    ).to eq(Set.new([:b]))
+    ).to eq(Set.new(%i[id created_at updated_at b]))
 
     expect(
       another_klass.class_variable_get(:@@index_attributes),
@@ -49,7 +49,7 @@ describe Redcord::Attribute do
 
     expect(
       another_klass.class_variable_get(:@@range_index_attributes),
-    ).to eq(Set.new(%i[float integer time]))
+    ).to eq(Set.new(%i[id created_at updated_at float integer time]))
 
     expect(
       another_klass.class_variable_get(:@@ttl),


### PR DESCRIPTION
### Motivation
This sets default attributes such as id,created_at,updated_at to be indexed attributes so we can query those attributes using where and find_by

### Note
- Backward compatibility: existing records won't have index maintained, thus they're not visible to the where/find_by queries.
- Since the API is newly added, it could be fine to just treat the old records "does not exist" since the API is mainly for models created with a newer version of Redcord
- We can also run add_index migration for the existing records after this patch

Thoughts?