### PR TITLE
Increase test coverage in migration/version_spec

### DIFF
--- a/lib/redcord/migration/version.rb
+++ b/lib/redcord/migration/version.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 # typed: strict
+
 class Redcord::Migration::Version
   extend T::Sig
 

--- a/spec/migration/version_spec.rb
+++ b/spec/migration/version_spec.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 # typed: false
+
 describe Redcord::Migration::Version do
   let(:redis) { Redcord::Base.redis }
   let(:migrator) { Redcord::Migration::Migrator }
@@ -10,8 +13,9 @@ describe Redcord::Migration::Version do
 
   context 'when there a new migration file locally' do
     before(:each) do
-      allow_any_instance_of(Redcord::Migration::Version).to receive(:local_versions)
-        .and_return([migration_file])
+      allow(Redcord::Migration::Migrator).to receive(:migration_files) do
+        [migration_file]
+      end
     end
 
     it 'needs to migrate the redis db' do
@@ -21,10 +25,12 @@ describe Redcord::Migration::Version do
 
   context 'when there is no new migration file locally' do
     before(:each) do
-      allow_any_instance_of(Redcord::Migration::Version).to receive(:local_versions)
-        .and_return([])
-      allow_any_instance_of(Redcord::Migration::Version).to receive(:remote_versions)
-        .and_return([])
+      allow_any_instance_of(Redcord::Migration::Version).to(
+        receive(:local_versions).and_return([]),
+      )
+      allow_any_instance_of(Redcord::Migration::Version).to(
+        receive(:remote_versions).and_return([]),
+      )
     end
 
     it 'does not need to migrate the redis db' do


### PR DESCRIPTION
This changes the mocking level in `migration/version_spec`, to cover more code path in rspec.