### PR TITLE
Support rails versions >= 5

### DIFF
--- a/redcord.gemspec
+++ b/redcord.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ['>= 2.5.0']
 
-  s.add_dependency 'activesupport', '~> 5'
-  s.add_dependency 'railties', '~> 5'
+  s.add_dependency 'activesupport', '>= 5'
+  s.add_dependency 'railties', '>= 5'
   s.add_dependency 'redis', '~> 4'
   s.add_dependency 'sorbet', '>= 0.4.4704'
   s.add_dependency 'sorbet-coerce', '>= 0.2.7'


### PR DESCRIPTION
### Motivation
This bumps the rails gems versions in gemspec. The code is already compatible with rails 6.

### Test Plan
- [ ] No build failures.