### PR TITLE
Add tracer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ Finished in 0.024 second
 
 Learn more: [Migrations](docs/migrations.md)
 
+### 6. Monitoring
+Redcord reports metrics to a tracer (for example, [Datadog APM](https://docs.datadoghq.com/tracing/setup/ruby/#manual-instrumentation)) if it is configured.
+
+In `config/initializers/redcord.rb`, provide a block with a Ruby object that responds to  `.trace(<span_name>, <options hash>)`.
+```ruby
+Redcord.configure do |config|
+  # Don’t forget to enable manual-instrumentation in datadog’s configuration!
+  config.tracer { Datadog.tracer }
+end
+```
+
 ## Related Projects; Yet Another Redcord
 To the best of our knowledge, Redcord is the best Ruby ORM lib for Redis.
 

--- a/lib/redcord.rb
+++ b/lib/redcord.rb
@@ -1,8 +1,35 @@
+# frozen_string_literal: true
+
 # typed: strict
-module Redcord
-end
 
 require 'sorbet-runtime'
+
+module Redcord
+  extend T::Sig
+
+  @@configuration_blks = T.let(
+    [],
+    T::Array[T.proc.params(arg0: T.untyped).void],
+  )
+
+  sig {
+    params(
+      blk: T.proc.params(arg0: T.untyped).void,
+    ).void
+  }
+  def self.configure(&blk)
+    @@configuration_blks << blk
+  end
+
+  sig { void }
+  def self._after_initialize!
+    @@configuration_blks.each do |blk|
+      blk.call(Redcord::Base)
+    end
+
+    @@configuration_blks.clear
+  end
+end
 
 require 'redcord/base'
 require 'redcord/migration'

--- a/lib/redcord/actions.rb
+++ b/lib/redcord/actions.rb
@@ -26,27 +26,42 @@ module Redcord::Actions
 
     sig { params(args: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
     def create!(args)
-      args[:created_at] = args[:updated_at] = Time.zone.now
-      instance = TypeCoerce[self].new.from(args)
-      id = redis.create_hash_returning_id(model_key, to_redis_hash(args))
-      instance.send(:id=, id)
-      instance
+      Redcord::Base.trace(
+       'redcord_actions_class_methods_create!',
+        model_name: name,
+      ) do
+        args[:created_at] = args[:updated_at] = Time.zone.now
+        instance = TypeCoerce[self].new.from(args)
+        id = redis.create_hash_returning_id(model_key, to_redis_hash(args))
+        instance.send(:id=, id)
+        instance
+      end
     end
 
     sig { params(id: T.untyped).returns(T.untyped) }
     def find(id)
-      instance_key = "#{model_key}:id:#{id}"
-      args = redis.hgetall(instance_key)
-      if args.empty?
-        raise Redcord::RecordNotFound, "Couldn't find #{name} with 'id'=#{id}"
-      end
+      Redcord::Base.trace(
+       'redcord_actions_class_methods_find',
+        model_name: name,
+      ) do
+        instance_key = "#{model_key}:id:#{id}"
+        args = redis.hgetall(instance_key)
+        if args.empty?
+          raise Redcord::RecordNotFound, "Couldn't find #{name} with 'id'=#{id}"
+        end
 
-      coerce_and_set_id(args, id)
+        coerce_and_set_id(args, id)
+      end
     end
 
     sig { params(args: T::Hash[Symbol, T.untyped]).returns(T.untyped) }
     def find_by(args)
-      where(args).to_a.first
+      Redcord::Base.trace(
+       'redcord_actions_class_methods_find_by_args',
+        model_name: name,
+      ) do
+        where(args).to_a.first
+      end
     end
 
     sig { params(args: T::Hash[Symbol, T.untyped]).returns(Redcord::Relation) }
@@ -56,7 +71,12 @@ module Redcord::Actions
 
     sig { params(id: T.untyped).returns(T::Boolean) }
     def destroy(id)
-      redis.delete_hash(model_key, id) == 1
+      Redcord::Base.trace(
+       'redcord_actions_class_methods_destroy',
+        model_name: name,
+      ) do
+        redis.delete_hash(model_key, id) == 1
+      end
     end
   end
 
@@ -88,46 +108,61 @@ module Redcord::Actions
 
     sig { void }
     def save!
-      self.updated_at = Time.zone.now
-      _id = id
-      if _id.nil?
-        self.created_at = T.must(self.updated_at)
-        _id = redis.create_hash_returning_id(
-          self.class.model_key,
-          self.class.to_redis_hash(serialize),
-        )
-        send(:id=, _id)
-      else
-        redis.update_hash(
-          self.class.model_key,
-          _id,
-          self.class.to_redis_hash(serialize),
-        )
+      Redcord::Base.trace(
+       'redcord_actions_instance_methods_save!',
+        model_name: self.class.name,
+      ) do
+        self.updated_at = Time.zone.now
+        _id = id
+        if _id.nil?
+          self.created_at = T.must(self.updated_at)
+          _id = redis.create_hash_returning_id(
+            self.class.model_key,
+            self.class.to_redis_hash(serialize),
+          )
+          send(:id=, _id)
+        else
+          redis.update_hash(
+            self.class.model_key,
+            _id,
+            self.class.to_redis_hash(serialize),
+          )
+        end
       end
     end
 
     sig { params(args: T::Hash[Symbol, T.untyped]).void }
     def update!(args = {})
-      _id = id
-      if _id.nil?
-        _set_args!(args)
-        save!
-      else
-        args[:updated_at] = Time.zone.now
-        _set_args!(args)
-        redis.update_hash(
-          self.class.model_key,
-          _id,
-          self.class.to_redis_hash(args),
-        )
+      Redcord::Base.trace(
+       'redcord_actions_instance_methods_update!',
+        model_name: self.class.name,
+      ) do
+        _id = id
+        if _id.nil?
+          _set_args!(args)
+          save!
+        else
+          args[:updated_at] = Time.zone.now
+          _set_args!(args)
+          redis.update_hash(
+            self.class.model_key,
+            _id,
+            self.class.to_redis_hash(args),
+          )
+        end
       end
     end
 
     sig { returns(T::Boolean) }
     def destroy
-      return false if id.nil?
+      Redcord::Base.trace(
+       'redcord_actions_instance_methods_destroy',
+        model_name: self.class.name,
+      ) do
+        return false if id.nil?
 
-      self.class.destroy(T.must(id))
+        self.class.destroy(T.must(id))
+      end
     end
 
     sig { returns(String) }

--- a/lib/redcord/base.rb
+++ b/lib/redcord/base.rb
@@ -13,6 +13,7 @@ require 'redcord/configurations'
 require 'redcord/logger'
 require 'redcord/redis_connection'
 require 'redcord/serializer'
+require 'redcord/tracer'
 
 module Redcord::Base
   extend T::Sig
@@ -25,6 +26,7 @@ module Redcord::Base
   include Redcord::Configurations
   include Redcord::Logger
   include Redcord::RedisConnection
+  include Redcord::Tracer
 
   abstract!
 

--- a/lib/redcord/configurations.rb
+++ b/lib/redcord/configurations.rb
@@ -42,6 +42,7 @@
 #  ```
 #
 require 'redcord/redis_connection'
+require 'redcord/tracer'
 
 module Redcord::Configurations
   extend T::Sig

--- a/lib/redcord/railtie.rb
+++ b/lib/redcord/railtie.rb
@@ -28,5 +28,6 @@ class Redcord::Railtie < Rails::Railtie
     end
 
     Redcord::PreparedRedis.load_server_scripts!
+    Redcord._after_initialize!
   end
 end

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -51,14 +51,19 @@ class Redcord::Relation
   ).returns(T.any(Redcord::Relation, T::Array[T.untyped]))
   end
   def select(*args, &blk)
-    if block_given?
-      return execute_query.select do |*item|
-        blk.call(*item)
+    Redcord::Base.trace(
+     'redcord_relation_select',
+     model_name: model.name,
+    ) do
+      if block_given?
+        return execute_query.select do |*item|
+          blk.call(*item)
+        end
       end
-    end
 
-    select_attrs.merge(args)
-    self
+      select_attrs.merge(args)
+      self
+    end
   end
 
   sig { returns(Integer) }
@@ -134,25 +139,30 @@ class Redcord::Relation
 
   sig { returns(T::Array[T.untyped]) }
   def execute_query
-    if !select_attrs.empty?
-      res_hash = redis.find_by_attr(
-        model.model_key,
-        query_conditions,
-        select_attrs,
-      )
+    Redcord::Base.trace(
+     'redcord_relation_execute_query',
+     model_name: model.name,
+    ) do
+      if !select_attrs.empty?
+        res_hash = redis.find_by_attr(
+          model.model_key,
+          query_conditions,
+          select_attrs,
+        )
 
-      res_hash.map do |id, args|
-        model.from_redis_hash(args).map do |k, v|
-          [k.to_sym, TypeCoerce[model.get_attr_type(k.to_sym)].new.from(v)]
-        end.to_h.merge(id: id)
+        res_hash.map do |id, args|
+          model.from_redis_hash(args).map do |k, v|
+            [k.to_sym, TypeCoerce[model.get_attr_type(k.to_sym)].new.from(v)]
+          end.to_h.merge(id: id)
+        end
+      else
+        res_hash = redis.find_by_attr(
+          model.model_key,
+          query_conditions,
+        )
+
+        res_hash.map { |id, args| model.coerce_and_set_id(args, id) }
       end
-    else
-      res_hash = redis.find_by_attr(
-        model.model_key,
-        query_conditions,
-      )
-
-      res_hash.map { |id, args| model.coerce_and_set_id(args, id) }
     end
   end
 

--- a/lib/redcord/tracer.rb
+++ b/lib/redcord/tracer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# typed: strict
+
+module Redcord::Tracer
+  extend T::Sig
+  extend T::Helpers
+
+  sig { params(klass: Module).void }
+  def self.included(klass)
+    klass.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    include Kernel
+
+    extend T::Sig
+
+    @@tracer = T.let(nil, T.untyped)
+
+    sig {
+      params(
+        span_name: String,
+        model_name: String,
+        tags: T::Array[String],
+        blk: T.proc.returns(T.untyped),
+      ).returns(T.untyped)
+    }
+    def trace(span_name, model_name:, tags: [], &blk)
+      return blk.call if @@tracer.nil?
+
+      @@tracer.call.trace(
+        span_name,
+        resource: model_name,
+        service: 'redcord',
+        tags: tags,
+        &blk
+      )
+    end
+
+    sig { params(blk: T.proc.returns(T.untyped)).void }
+    def tracer(&blk)
+      @@tracer = blk
+    end
+  end
+
+  mixes_in_class_methods(ClassMethods)
+end

--- a/spec/tracer_spec.rb
+++ b/spec/tracer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# typed: false
+
+describe Redcord::Tracer do
+  class FakeTracer
+    def trace(*)
+      yield
+    end
+  end
+
+  context 'when tracer is set' do
+    include Redcord::Tracer::ClassMethods
+
+    let(:tracer) { proc { FakeTracer.new } }
+
+    it 'records traces' do
+      counter = 0
+
+      expect(
+        trace('test', model_name: 'test') { counter += 1 }
+      ).to be 1
+      expect(counter).to be 1
+    end
+  end
+
+  context 'when tracer is not set' do
+    include Redcord::Tracer::ClassMethods
+
+    let(:tracer) { nil }
+
+    it 'does not record traces' do
+      counter = 0
+      expect(
+        trace('test', model_name: 'test') { counter += 2 }
+      ).to be 2
+      expect(counter).to be 2
+    end
+  end
+end


### PR DESCRIPTION
This allows users to add a tracer (for example, datadog's APM tracer) so the metrics/spans will be reported to the tracer.

### Test Plan
- [x] This integration works in a test project
- [x] Added test cases to cover the new behavior