### PR TITLE
Fix loading errors

### DIFF
--- a/lib/redcord/prepared_redis.rb
+++ b/lib/redcord/prepared_redis.rb
@@ -81,7 +81,10 @@ class Redcord::PreparedRedis < Redis
 
   sig { void }
   def load_server_scripts!
-    script_names = Dir['lib/redcord/server_scripts/*.lua'].map do |filename|
+    script_names = Dir[File.join(
+      __dir__,
+      'server_scripts/*.lua',
+    )].map do |filename|
       # lib/redcord/server_scripts/find_by_attr.erb.lua -> find_by_attr
       T.must(filename.split('/').last).split('.').first&.to_sym
     end

--- a/lib/redcord/railtie.rb
+++ b/lib/redcord/railtie.rb
@@ -22,7 +22,7 @@ class Redcord::Railtie < Rails::Railtie
     config_file = 'config/redcord.yml'
 
     if File.file?(config_file)
-      Redcord::Base.configurations = YAML.safe_load(
+      Redcord::Base.configurations = YAML.load(
         ERB.new(File.read(config_file)).result
       )
     end


### PR DESCRIPTION
This fixes some errors that prevent the lib from working properly:
1. YAML.safe_load does not allow certain key names
2. Use the absolute script path instead

### Test Plan
- [x] Integrate the gem into a test project; ensure it works.