### PR TITLE
Set logger after init

### DIFF
--- a/lib/redcord/logger.rb
+++ b/lib/redcord/logger.rb
@@ -12,7 +12,7 @@ module Redcord::Logger
   module ClassMethods
     extend T::Sig
 
-    @@logger = T.let(Rails.logger, T.untyped)
+    @@logger = T.let(nil, T.untyped)
 
     sig { returns(T.untyped) }
     def logger

--- a/lib/redcord/railtie.rb
+++ b/lib/redcord/railtie.rb
@@ -19,6 +19,8 @@ class Redcord::Railtie < Rails::Railtie
   end
 
   config.after_initialize do
+    Redcord::Base.logger = Rails.logger
+
     config_file = 'config/redcord.yml'
 
     if File.file?(config_file)


### PR DESCRIPTION
Currently, the Redcord logger is always nil. We should set it after initializing the lib.