### PR TITLE
Fix maintaining the id index set for the delete operation

### DIFF
--- a/lib/redcord/server_scripts/delete_hash.erb.lua
+++ b/lib/redcord/server_scripts/delete_hash.erb.lua
@@ -42,6 +42,7 @@ if #range_index_attr_keys > 0 then
   for i=1, #range_index_attr_keys do
     delete_id_from_range_index_attr(model, range_index_attr_keys[i], attr_vals[i], id)
   end
+  -- We have to explicitly delete from the id index set, because hmget does not return the id.
   redis.call('zrem', model .. ':id', id)
 end
 

--- a/lib/redcord/server_scripts/delete_hash.erb.lua
+++ b/lib/redcord/server_scripts/delete_hash.erb.lua
@@ -41,6 +41,7 @@ if #range_index_attr_keys > 0 then
   local attr_vals = redis.call('hmget', key, unpack(range_index_attr_keys))
   for i=1, #range_index_attr_keys do
     delete_id_from_range_index_attr(model, range_index_attr_keys[i], attr_vals[i], id)
+    redis.call('zrem', model .. ':' .. range_index_attr_keys[i], id)
   end
 end
 

--- a/lib/redcord/server_scripts/delete_hash.erb.lua
+++ b/lib/redcord/server_scripts/delete_hash.erb.lua
@@ -41,8 +41,8 @@ if #range_index_attr_keys > 0 then
   local attr_vals = redis.call('hmget', key, unpack(range_index_attr_keys))
   for i=1, #range_index_attr_keys do
     delete_id_from_range_index_attr(model, range_index_attr_keys[i], attr_vals[i], id)
-    redis.call('zrem', model .. ':' .. range_index_attr_keys[i], id)
   end
+  redis.call('zrem', model .. ':id', id)
 end
 
 -- delete the actual key

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -46,6 +46,7 @@ describe Redcord::Relation do
 
     queried_instances = klass.where(a: 3)
     expect(queried_instances.size).to eq 0
+    expect(klass.redis.zcard("#{klass.model_key}:id")).to eq 0
   end
 
   it 'supports chaining select index query method' do


### PR DESCRIPTION
### Summary
Fix updating the id index set when a redcord is destroyed

### Test Plan
Spec to confirm cardinality of set is expected