### PR TITLE
[feature] Sharding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@
 
 /log
 /sorbet/rbi/hidden-definitions/errors.txt
+redcord_spec_redis_cluster.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 services:
 - redis-server
+- docker
 rvm:
 - 2.5
 - 2.6
@@ -10,10 +11,14 @@ matrix:
   allow_failures:
   - rvm: ruby-head
 before_install:
+- docker pull redis
 - gem install bundler -v 2.0.1 --no-doc
 script:
 - bundle exec rspec
 env:
+  matrix:
+  - REDCORD_SPEC_USE_CLUSTER=true
+  - REDCORD_SPEC_USE_CLUSTER=false
   global:
     secure: XMu8bnfjfCE0hCU4OgfvZ5asqingSzDahPGdVIzUej50uRrAlJ8oi765ZbwQGUcRIixy2JW417zqpImzKpn4d32OEjbpdgYWGTj1ENb9KYvlj1rgziHgvsArUi0CNpWSoDP8bFZPYwF5Db547WaJDp56sK1ddWlTanhsYAgYj4jN4dPblHTicOa8BXlwDSHfmj9GinJsHp0M+vXoORvLje3qIbgcW0/hjzYUStbaA0ciJHJdz7ubadXO11Z9pvn6gEamc+D71Yvtv4xguvSx8x4t+Ac3D1oqCEAaGnD2st06vU7aeJZpMajkAM5mDUGzAcnPHrN0iH/LfDwtcbaJq3U1EgNUPwZF7EtnRn6se3DURY0GKo0GMMos0xAc0wW9A76K2z++U+2AKP/Of5BZ8qufwi0UyiMgCb6M1hMOPzfvr+jlyAbq7K1WUwDp1DEq9gCE/JTk0sgdk4iU8x7C+8uckHigh94V9VJDxuT4xUPrulIM9dI/3gw7nnSvW7SiaS9Jj2b1DXqeKdtEQOlK/Oh1YG03c6qkbl+l3L/EP69AJhS8t9QyytuFr/XTuP4efINLAbsRy0HkG4MHvn7sN2+o69obz9TZpnbXIwBDJdphpMFuqcq7u8hIUYMitNY0d6sakb1jwZNLdOjbatXn6Phwa1f1teQ1sbaJUUsTmTE=
 deploy:

--- a/lib/redcord/actions.rb
+++ b/lib/redcord/actions.rb
@@ -35,9 +35,9 @@ module Redcord::Actions
         id = redis.create_hash_returning_id(
           model_key,
           to_redis_hash(args),
-          ttl: class_variable_get(:@@ttl)&.to_i || -1,
-          index_attrs: class_variable_get(:@@index_attributes).to_a,
-          range_index_attrs: class_variable_get(:@@range_index_attributes).to_a,
+          ttl: _script_arg_ttl,
+          index_attrs: _script_arg_index_attrs,
+          range_index_attrs: _script_arg_range_index_attrs,
           hash_tag: instance.hash_tag,
         )
         instance.send(:id=, id)
@@ -85,8 +85,8 @@ module Redcord::Actions
         redis.delete_hash(
           model_key,
           id,
-          index_attrs: class_variable_get(:@@index_attributes).to_a,
-          range_index_attrs: class_variable_get(:@@range_index_attributes).to_a,
+          index_attrs: _script_arg_index_attrs,
+          range_index_attrs: _script_arg_range_index_attrs,
         ) == 1
       end
     end
@@ -131,9 +131,9 @@ module Redcord::Actions
           _id = redis.create_hash_returning_id(
             self.class.model_key,
             self.class.to_redis_hash(serialize),
-            ttl: self.class.class_variable_get(:@@ttl)&.to_i || -1,
-            index_attrs: self.class.class_variable_get(:@@index_attributes).to_a,
-            range_index_attrs: self.class.class_variable_get(:@@range_index_attributes).to_a,
+            ttl: self.class._script_arg_ttl,
+            index_attrs: self.class._script_arg_index_attrs,
+            range_index_attrs: self.class._script_arg_range_index_attrs,
             hash_tag: hash_tag,
           )
           send(:id=, _id)
@@ -142,9 +142,9 @@ module Redcord::Actions
             self.class.model_key,
             _id,
             self.class.to_redis_hash(serialize),
-            ttl: self.class.class_variable_get(:@@ttl)&.to_i || -1,
-            index_attrs: self.class.class_variable_get(:@@index_attributes).to_a,
-            range_index_attrs: self.class.class_variable_get(:@@range_index_attributes).to_a,
+            ttl: self.class._script_arg_ttl,
+            index_attrs: self.class._script_arg_index_attrs,
+            range_index_attrs: self.class._script_arg_range_index_attrs,
             hash_tag: hash_tag,
           )
         end
@@ -173,9 +173,9 @@ module Redcord::Actions
             self.class.model_key,
             _id,
             self.class.to_redis_hash(args),
-            ttl: self.class.class_variable_get(:@@ttl)&.to_i || -1,
-            index_attrs: self.class.class_variable_get(:@@index_attributes).to_a,
-            range_index_attrs: self.class.class_variable_get(:@@range_index_attributes).to_a,
+            ttl: self.class._script_arg_ttl,
+            index_attrs: self.class._script_arg_index_attrs,
+            range_index_attrs: self.class._script_arg_range_index_attrs,
             hash_tag: hash_tag,
           )
         end

--- a/lib/redcord/actions.rb
+++ b/lib/redcord/actions.rb
@@ -157,6 +157,11 @@ module Redcord::Actions
        'redcord_actions_instance_methods_update!',
         model_name: self.class.name,
       ) do
+        shard_by_attr = self.class.class_variable_get(:@@shard_by_attribute)
+        if args.keys.include?(shard_by_attr)
+          raise "Cannot update shard_by attribute #{shard_by_attr}"
+        end
+
         _id = id
         if _id.nil?
           _set_args!(args)

--- a/lib/redcord/actions.rb
+++ b/lib/redcord/actions.rb
@@ -32,7 +32,7 @@ module Redcord::Actions
       ) do
         args[:created_at] = args[:updated_at] = Time.zone.now
         instance = TypeCoerce[self].new.from(args)
-        id = redis.create_hash_returning_id(model_key, to_redis_hash(args))
+        id = redis.create_hash_returning_id(model_key, to_redis_hash(args), instance.hash_tag)
         instance.send(:id=, id)
         instance
       end
@@ -177,14 +177,14 @@ module Redcord::Actions
       end
     end
 
-    sig { returns(T.nilable(Integer)) }
+    sig { returns(T.nilable(String)) }
     def id
       instance_variable_get(:@_id)
     end
 
     private
 
-    sig { params(id: Integer).returns(Integer) }
+    sig { params(id: String).returns(String) }
     def id=(id)
       instance_variable_set(:@_id, id)
     end

--- a/lib/redcord/attribute.rb
+++ b/lib/redcord/attribute.rb
@@ -83,7 +83,8 @@ module Redcord::Attribute
 
       return nil if attr.nil?
 
-      "{#{send(attr)}}"
+      # A blank hash tag would cause MOVED error in cluster mode
+      "{#{send(attr) || '__redcord_hash_tag_null__'}}"
     end
   end
 

--- a/lib/redcord/attribute.rb
+++ b/lib/redcord/attribute.rb
@@ -65,6 +65,10 @@ module Redcord::Attribute
         raise "Cannot shard by a non-index attribute '#{attr}'"
       end
 
+      # shard_by_attribute is treated as a regular index attribute
+      class_variable_get(:@@index_attributes).add(attr)
+      class_variable_get(:@@range_index_attributes).delete(attr)
+
       class_variable_set(:@@shard_by_attribute, attr)
     end
 
@@ -108,7 +112,7 @@ module Redcord::Attribute
       default_tag = '__redcord_hash_tag_null__'
 
       if tag == default_tag
-        raise "#{attr}=#{default_tag} conflict with default hash_tag value"
+        raise "#{attr}=#{default_tag} conflicts with default hash_tag value"
       end
 
       "{#{tag || default_tag}}"

--- a/lib/redcord/attribute.rb
+++ b/lib/redcord/attribute.rb
@@ -48,10 +48,8 @@ module Redcord::Attribute
     def index_attribute(attr, type)
       if should_range_index?(type)
         class_variable_get(:@@range_index_attributes) << attr
-        sadd_proc_on_redis_connection('range_index_attrs', attr.to_s)
       else
         class_variable_get(:@@index_attributes) << attr
-        sadd_proc_on_redis_connection('index_attrs', attr.to_s)
       end
     end
 
@@ -66,16 +64,6 @@ module Redcord::Attribute
     end
 
     private
-
-    sig { params(redis_key: String, item_to_add: String).void }
-    def sadd_proc_on_redis_connection(redis_key, item_to_add)
-      # TODO: Currently we're setting indexed attributes through procs that are
-      # run when a RedisConnection is established. This should be replaced with
-      # migrations
-      Redcord::RedisConnection.procs_to_prepare << proc do |redis|
-        redis.sadd("#{model_key}:#{redis_key}", item_to_add)
-      end
-    end
 
     sig { params(type: T.any(Class, T::Types::Base)).returns(T::Boolean) }
     def should_range_index?(type)
@@ -95,7 +83,7 @@ module Redcord::Attribute
 
       return nil if attr.nil?
 
-      send(attr)
+      "{#{send(attr)}}"
     end
   end
 

--- a/lib/redcord/railtie.rb
+++ b/lib/redcord/railtie.rb
@@ -29,7 +29,7 @@ class Redcord::Railtie < Rails::Railtie
       )
     end
 
-    Redcord::PreparedRedis.load_server_scripts!
+    Redcord::Redis.load_server_scripts!
     Redcord._after_initialize!
   end
 end

--- a/lib/redcord/railtie.rb
+++ b/lib/redcord/railtie.rb
@@ -29,7 +29,6 @@ class Redcord::Railtie < Rails::Railtie
       )
     end
 
-    Redcord::Redis.load_server_scripts!
     Redcord._after_initialize!
   end
 end

--- a/lib/redcord/redis.rb
+++ b/lib/redcord/redis.rb
@@ -1,44 +1,48 @@
 # typed: strict
 require 'redis'
+require 'securerandom'
 
-# TODO: Rename Redcord::PreparedRedis -> Redcord::Redis
-class Redcord::PreparedRedis < Redis
+class Redcord::Redis < Redis
   extend T::Sig
 
   sig do
     params(
       key: T.any(String, Symbol),
       args: T::Hash[T.untyped, T.untyped],
-    ).returns(Integer)
+      hash_tag: T.nilable(String),
+    ).returns(String)
   end
-  def create_hash_returning_id(key, args)
+  def create_hash_returning_id(key, args, hash_tag=nil)
     Redcord::Base.trace(
       'redcord_redis_create_hash_returning_id',
       model_name: key,
     ) do
+      id = "#{SecureRandom.uuid}{#{hash_tag}}"
       evalsha(
-        self.class.server_script_shas[:create_hash_returning_id],
-        keys: [key],
+        self.class.server_script_shas[:create_hash],
+        keys: [key, id],
         argv: args.to_a.flatten,
-      ).to_i
+      )
+      id
     end
   end
 
   sig do
     params(
       model: String,
-      id: Integer,
+      id: String,
       args: T::Hash[T.untyped, T.untyped],
+      hash_tag: T.nilable(String),
     ).void
   end
-  def update_hash(model, id, args)
+  def update_hash(model, id, args, hash_tag=nil)
     Redcord::Base.trace(
       'redcord_redis_update_hash',
       model_name: model,
     ) do
       evalsha(
         self.class.server_script_shas[:update_hash],
-        keys: [model, id],
+        keys: [model, id, "{#{hash_tag}}"],
         argv: args.to_a.flatten,
       )
     end
@@ -47,17 +51,18 @@ class Redcord::PreparedRedis < Redis
   sig do
     params(
       model: String,
-      id: Integer
+      id: String, 
+      hash_tag: T.nilable(String),
     ).returns(Integer)
   end
-  def delete_hash(model, id)
+  def delete_hash(model, id, hash_tag=nil)
     Redcord::Base.trace(
       'redcord_redis_delete_hash',
       model_name: model,
     ) do
       evalsha(
         self.class.server_script_shas[:delete_hash],
-        keys: [model, id]
+        keys: [model, id, "{#{hash_tag}}"]
       )
     end
   end
@@ -66,40 +71,42 @@ class Redcord::PreparedRedis < Redis
     params(
       model: String,
       query_conditions: T::Hash[T.untyped, T.untyped],
-      select_attrs: T::Set[Symbol]
+      select_attrs: T::Set[Symbol],
+      hash_tag: T.nilable(String),
     ).returns(T::Hash[Integer, T::Hash[T.untyped, T.untyped]])
   end
-  def find_by_attr(model, query_conditions, select_attrs=Set.new)
+  def find_by_attr(model, query_conditions, select_attrs=Set.new, hash_tag=nil)
     Redcord::Base.trace(
       'redcord_redis_find_by_attr',
       model_name: model,
     ) do
       res = evalsha(
         self.class.server_script_shas[:find_by_attr],
-        keys: [model] + query_conditions.to_a.flatten,
+        keys: [model] + query_conditions.to_a.flatten + ["{#{hash_tag}}"],
         argv: select_attrs.to_a.flatten
       )
       # The Lua script will return this as a flattened array.
       # Convert the result into a hash of {id -> model hash}
       res_hash = res.each_slice(2)
-      res_hash.map { |key, val| [key.to_i, val.each_slice(2).to_h] }.to_h
+      res_hash.map { |key, val| [key, val.each_slice(2).to_h] }.to_h
     end
   end
 
   sig do
     params(
       model: String,
-      query_conditions: T::Hash[T.untyped, T.untyped]
+      query_conditions: T::Hash[T.untyped, T.untyped],
+      hash_tag: T.nilable(String),
     ).returns(Integer)
   end
-  def find_by_attr_count(model, query_conditions)
+  def find_by_attr_count(model, query_conditions, hash_tag=nil)
     Redcord::Base.trace(
       'redcord_redis_find_by_attr_count',
       model_name: model,
     ) do
       evalsha(
         self.class.server_script_shas[:find_by_attr_count],
-        keys: [model] + query_conditions.to_a.flatten,
+        keys: [model] + query_conditions.to_a.flatten + ["{#{hash_tag}}"],
       )
     end
   end

--- a/lib/redcord/redis.rb
+++ b/lib/redcord/redis.rb
@@ -10,19 +10,22 @@ class Redcord::Redis < Redis
     params(
       key: T.any(String, Symbol),
       args: T::Hash[T.untyped, T.untyped],
+      ttl: T.nilable(Integer),
+      index_attrs: T::Array[Symbol],
+      range_index_attrs: T::Array[Symbol],
       hash_tag: T.nilable(String),
     ).returns(String)
   end
-  def create_hash_returning_id(key, args, hash_tag=nil)
+  def create_hash_returning_id(key, args, ttl:, index_attrs:, range_index_attrs:, hash_tag: nil)
     Redcord::Base.trace(
       'redcord_redis_create_hash_returning_id',
       model_name: key,
     ) do
-      id = "#{SecureRandom.uuid}{#{hash_tag}}"
+      id = "#{SecureRandom.uuid}#{hash_tag}"
       run_script(
-        self.class.server_script_shas[:create_hash],
-        keys: [key, id],
-        argv: args.to_a.flatten,
+        :create_hash,
+        keys: [id, hash_tag],
+        argv: [key, ttl, index_attrs.size, range_index_attrs.size] + index_attrs + range_index_attrs + args.to_a.flatten,
       )
       id
     end
@@ -33,18 +36,21 @@ class Redcord::Redis < Redis
       model: String,
       id: String,
       args: T::Hash[T.untyped, T.untyped],
+      ttl: T.nilable(Integer),
+      index_attrs: T::Array[Symbol],
+      range_index_attrs: T::Array[Symbol],
       hash_tag: T.nilable(String),
     ).void
   end
-  def update_hash(model, id, args, hash_tag=nil)
+  def update_hash(model, id, args, ttl:, index_attrs:, range_index_attrs:, hash_tag:)
     Redcord::Base.trace(
       'redcord_redis_update_hash',
       model_name: model,
     ) do
       run_script(
-        self.class.server_script_shas[:update_hash],
-        keys: [model, id, "{#{hash_tag}}"],
-        argv: args.to_a.flatten,
+        :update_hash,
+        keys: [id, hash_tag],
+        argv: [model, ttl, index_attrs.size, range_index_attrs.size] + index_attrs + range_index_attrs + args.to_a.flatten,
       )
     end
   end
@@ -52,18 +58,20 @@ class Redcord::Redis < Redis
   sig do
     params(
       model: String,
-      id: String, 
-      hash_tag: T.nilable(String),
+      id: String,
+      index_attrs: T::Array[Symbol],
+      range_index_attrs: T::Array[Symbol],
     ).returns(Integer)
   end
-  def delete_hash(model, id, hash_tag=nil)
+  def delete_hash(model, id, index_attrs:, range_index_attrs:)
     Redcord::Base.trace(
       'redcord_redis_delete_hash',
       model_name: model,
     ) do
       run_script(
-        self.class.server_script_shas[:delete_hash],
-        keys: [model, id, "{#{hash_tag}}"]
+        :delete_hash,
+        keys: [id, id.match(/\{.*\}$/)&.send(:[], 0)],
+        argv: [model, index_attrs.size, range_index_attrs.size] + index_attrs + range_index_attrs,
       )
     end
   end
@@ -73,18 +81,21 @@ class Redcord::Redis < Redis
       model: String,
       query_conditions: T::Hash[T.untyped, T.untyped],
       select_attrs: T::Set[Symbol],
+      index_attrs: T::Array[Symbol],
+      range_index_attrs: T::Array[Symbol],
       hash_tag: T.nilable(String),
     ).returns(T::Hash[Integer, T::Hash[T.untyped, T.untyped]])
   end
-  def find_by_attr(model, query_conditions, select_attrs=Set.new, hash_tag=nil)
+  def find_by_attr(model, query_conditions, select_attrs=Set.new, index_attrs:, range_index_attrs:, hash_tag: nil)
     Redcord::Base.trace(
       'redcord_redis_find_by_attr',
       model_name: model,
     ) do
+      conditions = query_conditions.to_a.flatten
       res = run_script(
-        self.class.server_script_shas[:find_by_attr],
-        keys: [model] + query_conditions.to_a.flatten + ["{#{hash_tag}}"],
-        argv: select_attrs.to_a.flatten
+        :find_by_attr,
+        keys: [hash_tag],
+        argv: [model, index_attrs.size, range_index_attrs.size, conditions.size] + index_attrs + range_index_attrs + conditions + select_attrs.to_a.flatten
       )
       # The Lua script will return this as a flattened array.
       # Convert the result into a hash of {id -> model hash}
@@ -97,17 +108,21 @@ class Redcord::Redis < Redis
     params(
       model: String,
       query_conditions: T::Hash[T.untyped, T.untyped],
+      index_attrs: T::Array[Symbol],
+      range_index_attrs: T::Array[Symbol],
       hash_tag: T.nilable(String),
     ).returns(Integer)
   end
-  def find_by_attr_count(model, query_conditions, hash_tag=nil)
+  def find_by_attr_count(model, query_conditions, index_attrs:, range_index_attrs:, hash_tag: nil)
     Redcord::Base.trace(
       'redcord_redis_find_by_attr_count',
       model_name: model,
     ) do
+      p [model, index_attrs.size, range_index_attrs.size] + index_attrs + range_index_attrs + query_conditions.to_a.flatten,
       run_script(
-        self.class.server_script_shas[:find_by_attr_count],
-        keys: [model] + query_conditions.to_a.flatten + ["{#{hash_tag}}"],
+        :find_by_attr_count,
+        keys: [hash_tag],
+        argv: [model, index_attrs.size, range_index_attrs.size] + index_attrs + range_index_attrs + query_conditions.to_a.flatten,
       )
     end
   end
@@ -115,7 +130,8 @@ class Redcord::Redis < Redis
   private
 
   def run_script(script_name, *args)
-    hash = instance_variable_get(script_name)
+    hash_var_name = :"@script_sha_#{script_name}"
+    hash = instance_variable_get(hash_var_name)
     evalsha(hash, *args)
   rescue Redis::CommandError => e
     if e.message != 'NOSCRIPT No matching script. Please use EVAL.'
@@ -123,7 +139,7 @@ class Redcord::Redis < Redis
     end
 
     script_content = Redcord::LuaScriptReader.read_lua_script(script_name.to_s)
-    instance_variable_set(script_name, Digest::SHA1.hexdigest(script_content))
+    instance_variable_set(hash_var_name, Digest::SHA1.hexdigest(script_content))
     self.eval(script_content, *args)
   end
 end

--- a/lib/redcord/redis.rb
+++ b/lib/redcord/redis.rb
@@ -118,7 +118,6 @@ class Redcord::Redis < Redis
       'redcord_redis_find_by_attr_count',
       model_name: model,
     ) do
-      p [model, index_attrs.size, range_index_attrs.size] + index_attrs + range_index_attrs + query_conditions.to_a.flatten,
       run_script(
         :find_by_attr_count,
         keys: [hash_tag],
@@ -130,6 +129,7 @@ class Redcord::Redis < Redis
   private
 
   def run_script(script_name, *args)
+    # Use EVAL when a redis shard has not loaded the script before
     hash_var_name = :"@script_sha_#{script_name}"
     hash = instance_variable_get(hash_var_name)
     evalsha(hash, *args)

--- a/lib/redcord/redis.rb
+++ b/lib/redcord/redis.rb
@@ -152,10 +152,13 @@ class Redcord::Redis < Redis
     # Use EVAL when a redis shard has not loaded the script before
     hash_var_name = :"@script_sha_#{script_name}"
     hash = instance_variable_get(hash_var_name)
-    evalsha(hash, *args)
-  rescue Redis::CommandError => e
-    if e.message != 'NOSCRIPT No matching script. Please use EVAL.'
-      raise e
+
+    begin
+      return evalsha(hash, *args) if hash
+    rescue Redis::CommandError => e
+      if e.message != 'NOSCRIPT No matching script. Please use EVAL.'
+        raise e
+      end
     end
 
     script_content = Redcord::LuaScriptReader.read_lua_script(script_name.to_s)

--- a/lib/redcord/redis_connection.rb
+++ b/lib/redcord/redis_connection.rb
@@ -5,7 +5,7 @@
 require 'rails'
 
 require 'redcord/lua_script_reader'
-require 'redcord/prepared_redis'
+require 'redcord/redis'
 
 module Redcord::RedisConnection
   extend T::Sig
@@ -29,17 +29,17 @@ module Redcord::RedisConnection
       (env_config[name.underscore] || env_config['default']).symbolize_keys
     end
 
-    sig { returns(Redcord::PreparedRedis) }
+    sig { returns(Redcord::Redis) }
     def redis
       Redcord::RedisConnection.connections[name.underscore] ||= prepare_redis!
     end
 
-    sig { returns(Redcord::PreparedRedis) }
+    sig { returns(Redcord::Redis) }
     def establish_connection
       Redcord::RedisConnection.connections[name.underscore] = prepare_redis!
     end
 
-    sig { params(redis: Redis).returns(Redcord::PreparedRedis) }
+    sig { params(redis: Redis).returns(Redcord::Redis) }
     def redis=(redis)
       Redcord::RedisConnection.connections[name.underscore] =
         prepare_redis!(redis)
@@ -50,11 +50,11 @@ module Redcord::RedisConnection
     # definitions in each Redis query.
     #
     # TODO: Replace this with Redcord migrations
-    sig { params(client: T.nilable(Redis)).returns(Redcord::PreparedRedis) }
+    sig { params(client: T.nilable(Redis)).returns(Redcord::Redis) }
     def prepare_redis!(client = nil)
-      return client if client.is_a?(Redcord::PreparedRedis)
+      return client if client.is_a?(Redcord::Redis)
 
-      client = Redcord::PreparedRedis.new(
+      client = Redcord::Redis.new(
         **(
           if client.nil?
             connection_config
@@ -78,7 +78,7 @@ module Redcord::RedisConnection
   module InstanceMethods
     extend T::Sig
 
-    sig { returns(Redcord::PreparedRedis) }
+    sig { returns(Redcord::Redis) }
     def redis
       self.class.redis
     end

--- a/lib/redcord/redis_connection.rb
+++ b/lib/redcord/redis_connection.rb
@@ -65,12 +65,7 @@ module Redcord::RedisConnection
         logger: Redcord::Logger.proxy,
       )
 
-      client.pipelined do
-        Redcord::RedisConnection.procs_to_prepare.each do |proc_to_prepare|
-          proc_to_prepare.call(client)
-        end
-      end
-
+      client.ping
       client
     end
   end

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -156,12 +156,6 @@ class Redcord::Relation
     case condition
     when Integer, String
       "{#{condition}}"
-    when Array
-      if condition.size != 2 || condition.first != condition.last
-        raise 'Must query for equality on the sharded attribute'
-      end
-
-      "{#{condition.first}}"
     else
       raise "Does not support query condition #{condition} on a Redis Cluster"
     end

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -149,10 +149,22 @@ class Redcord::Relation
     return '' if attr.nil?
 
     if !query_conditions.keys.include?(attr)
-      raise "Queries must contain #{attr} attribute since model #{model.name} is shared by #{attr}"
+      raise "Queries must contain attribute '#{attr}' since model #{model.name} is shared by this attribute"
     end
 
-    "{#{query_conditions[attr]}}"
+    condition = query_conditions[attr]
+    case condition
+    when Integer, String
+      "{#{condition}}"
+    when Array
+      if condition.size != 2 || condition.first != condition.last
+        raise 'Must query for equality on the shared attribute'
+      end
+
+      "{#{condition.first}}"
+    else
+      raise "Does not support query condition #{condition} on a Redis Cluster"
+    end
   end
 
   sig { returns(T::Array[T.untyped]) }

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -166,7 +166,7 @@ class Redcord::Relation
     end
   end
 
-  sig { returns(Redcord::PreparedRedis) }
+  sig { returns(Redcord::Redis) }
   def redis
     model.redis
   end

--- a/lib/redcord/serializer.rb
+++ b/lib/redcord/serializer.rb
@@ -137,7 +137,7 @@ module Redcord::Serializer
     sig {
       params(
         redis_hash: T::Hash[T.untyped, T.untyped],
-        id: Integer,
+        id: String,
       ).returns(T.untyped)
     }
     def coerce_and_set_id(redis_hash, id)

--- a/lib/redcord/server_scripts/create_hash.erb.lua
+++ b/lib/redcord/server_scripts/create_hash.erb.lua
@@ -26,8 +26,7 @@ if #KEYS ~= 2 then
 end
 
 local id, hash_tag = unpack(KEYS)
-local model = ARGV[1]
-local ttl = ARGV[2]
+local model, ttl = unpack(ARGV)
 local key = model .. ':id:' .. id
 
 local index_attr_pos = 5

--- a/lib/redcord/server_scripts/create_hash.erb.lua
+++ b/lib/redcord/server_scripts/create_hash.erb.lua
@@ -16,31 +16,27 @@ The id of the created hash as a string.
 -- happens with keys (so ARGV[1], ARGV[2], ...).
 
 --   KEYS[1] = Model.name
+--   KEYS[2] = id
 --   ARGV[1...2N] = attr_key attr_val [attr_key attr_val ..]
 <%= include_lua 'shared/lua_helper_methods' %>
 <%= include_lua 'shared/index_helper_methods' %>
 
 -- Validate input to script before making Redis db calls
-if #KEYS ~= 1 then
-  error('Expected keys to be of size 1')
+if #KEYS ~= 2 then
+  error('Expected keys to be of size 2')
 end
 if #ARGV % 2 ~= 0 then
   error('Expected an even number of arguments')
 end
 
 local model = KEYS[1]
-
--- Call the Redis command: INCR "#{Model.name}:id_seq". If "#{Model.name}:id_seq" does
--- not exist, the command returns 0. It errors if the id_seq overflows a 64 bit
--- signed integer.
-redis.call('incr', model .. ':id_seq')
-
--- The Lua version used by Redis does not support 64 bit integers:
---   https://github.com/antirez/redis/issues/5261
--- We ignore the integer response from INCR and use the string response from
--- the GET/MGET command.
-local id, ttl = unpack(redis.call('mget', model .. ':id_seq', model .. ':ttl'))
+local id = KEYS[2]
+local ttl = redis.call('get', model .. ':ttl')
 local key = model .. ':id:' .. id
+
+if redis.call('exists', key) ~= 0 then
+  error(key .. ' already exists')
+end
 
 -- Forward the script arguments to the Redis command HSET.
 -- Call the Redis command: HSET "#{Model.name}:id:#{id}" field value ...
@@ -65,4 +61,4 @@ if #range_index_attr_keys > 0 then
     add_id_to_range_index_attr(model, attr_key, attrs_hash[attr_key], id)
   end
 end
-return id
+return nil

--- a/lib/redcord/server_scripts/delete_hash.erb.lua
+++ b/lib/redcord/server_scripts/delete_hash.erb.lua
@@ -12,36 +12,38 @@ The number of keys deleted from Redis
 -- The arguments can be accessed by Lua using the KEYS global variable in the
 -- form of a one-based array (so KEYS[1], KEYS[2], ...).
 --
---   KEYS[1] = Model.name
---   KEYS[2] = id
---   KEYS[3] = hash_tag
+--   KEYS = id, hash_tag
+--   ARGV = Model.name index_attr_size [index_attr_key ...] [range_index_attr_key ...]
 <%= include_lua 'shared/index_helper_methods' %>
 
 -- Validate input to script before making Redis db calls
-if #KEYS ~= 3 then
-  error('Expected keys of be of size 3')
+if #KEYS ~= 2 then
+  error('Expected keys of be of size 2')
 end
 
-local model = KEYS[1]
-local id = KEYS[2]
+local model = ARGV[1]
+local id, hash_tag = unpack(KEYS)
 
 -- key = "#{model}:id:{id}"
 local key = model .. ':id:' .. id
 
+local index_attr_pos = 3
+local range_attr_pos = index_attr_pos + ARGV[2]
+
 -- Clean up id sets for both index and range index attributes
-local index_attr_keys = redis.call('smembers', model .. ':index_attrs')
+local index_attr_keys = {unpack(ARGV, index_attr_pos, range_attr_pos - 1)}
 if #index_attr_keys > 0 then
 -- Retrieve old index attr values so we can delete them in the attribute id sets
   local attr_vals = redis.call('hmget', key, unpack(index_attr_keys))
   for i=1, #index_attr_keys do
-    delete_id_from_index_attr(model, index_attr_keys[i], attr_vals[i], id)
+    delete_id_from_index_attr(hash_tag, model, index_attr_keys[i], attr_vals[i], id)
   end
 end
-local range_index_attr_keys = redis.call('smembers', model .. ':range_index_attrs')
+local range_index_attr_keys = {unpack(ARGV, range_attr_pos)}
 if #range_index_attr_keys > 0 then
   local attr_vals = redis.call('hmget', key, unpack(range_index_attr_keys))
   for i=1, #range_index_attr_keys do
-    delete_id_from_range_index_attr(model, range_index_attr_keys[i], attr_vals[i], id)
+    delete_id_from_range_index_attr(hash_tag, model, range_index_attr_keys[i], attr_vals[i], id)
   end
 end
 

--- a/lib/redcord/server_scripts/delete_hash.erb.lua
+++ b/lib/redcord/server_scripts/delete_hash.erb.lua
@@ -14,11 +14,12 @@ The number of keys deleted from Redis
 --
 --   KEYS[1] = Model.name
 --   KEYS[2] = id
+--   KEYS[3] = hash_tag
 <%= include_lua 'shared/index_helper_methods' %>
 
 -- Validate input to script before making Redis db calls
-if #KEYS ~= 2 then
-  error('Expected keys of be of size 2')
+if #KEYS ~= 3 then
+  error('Expected keys of be of size 3')
 end
 
 local model = KEYS[1]

--- a/lib/redcord/server_scripts/find_by_attr.erb.lua
+++ b/lib/redcord/server_scripts/find_by_attr.erb.lua
@@ -16,8 +16,9 @@ A hash of id:model of all the ids that match the query conditions given.
 -- happens with keys (so ARGV[1], ARGV[2], ...).
 --
 --   KEYS[1] = hash_tag
---   ARGV = Model.name num_index_attr num_range_index_attr num_query_conditions ...
---
+--   ARGV = Model.name num_index_attr num_range_index_attr num_query_conditions [index_attrs ...] [range_index_attrs ...] [query_conidtions ...] [attr_selections ...]
+--          [query_conidtions ...]: [attr_key1 attr_val1 attr_key2 attr_val2 ...]
+--          [attr_selections ...]: [attr_key1 attr_key2 ...]
 --   For equality query conditions, key value pairs are expected to appear in
 --   the KEYS array as [attr_key, attr_val]
 --   For range query conditions, key value pairs are expected to appear in the

--- a/lib/redcord/server_scripts/find_by_attr.erb.lua
+++ b/lib/redcord/server_scripts/find_by_attr.erb.lua
@@ -15,7 +15,7 @@ A hash of id:model of all the ids that match the query conditions given.
 -- accessed by Lua using the ARGV global variable, very similarly to what
 -- happens with keys (so ARGV[1], ARGV[2], ...).
 --
---   KEYS[1] = Model.name attr_key attr_val [attr_key attr_val ..]
+--   KEYS[1] = Model.name attr_key attr_val [attr_key attr_val ..] hash_tag
 --   ARGV[1...N] = attr_key [attr_key ..]
 --
 --   For equality query conditions, key value pairs are expected to appear in
@@ -29,7 +29,7 @@ A hash of id:model of all the ids that match the query conditions given.
 <%= include_lua 'shared/lua_helper_methods' %>
 <%= include_lua 'shared/query_helper_methods' %>
 
-if #KEYS < 3 then
+if #KEYS < 4 then
   error('Expected keys to be at least of size 3')
 end
 

--- a/lib/redcord/server_scripts/find_by_attr_count.erb.lua
+++ b/lib/redcord/server_scripts/find_by_attr_count.erb.lua
@@ -15,7 +15,7 @@ An integer number of records that match the query conditions given.
 -- accessed by Lua using the ARGV global variable, very similarly to what
 -- happens with keys (so ARGV[1], ARGV[2], ...).
 --
---   KEYS[1] = Model.name attr_key attr_val [attr_key attr_val ..]
+--   KEYS[1] = Model.name attr_key attr_val [attr_key attr_val ..] hash_tag
 --
 --   For equality query conditions, key value pairs are expected to appear in
 --   the KEYS array as [attr_key, attr_val]
@@ -25,7 +25,7 @@ An integer number of records that match the query conditions given.
 <%= include_lua 'shared/lua_helper_methods' %>
 <%= include_lua 'shared/query_helper_methods' %>
 
-if #KEYS < 3 then
+if #KEYS < 4 then
   error('Expected keys to be at least of size 3')
 end
 

--- a/lib/redcord/server_scripts/shared/index_helper_methods.erb.lua
+++ b/lib/redcord/server_scripts/shared/index_helper_methods.erb.lua
@@ -1,61 +1,61 @@
 -- Add an id to the id set of the index attribute
-local function add_id_to_index_attr(model, attr_key, attr_val, id)
+local function add_id_to_index_attr(hash_tag, model, attr_key, attr_val, id)
   if attr_val then
     -- Call the Redis command: SADD "#{Model.name}:#{attr_name}:#{attr_val}" member ..
-    redis.call('sadd', model .. ':' .. attr_key .. ':' .. attr_val, id)
+    redis.call('sadd', model .. ':' .. attr_key .. ':' .. attr_val .. hash_tag, id)
   end
 end
 
 -- Remove an id from the id set of the index attribute
-local function delete_id_from_index_attr(model, attr_key, attr_val, id)
+local function delete_id_from_index_attr(hash_tag, model, attr_key, attr_val, id)
   if attr_val then
     -- Call the Redis command: SREM "#{Model.name}:#{attr_name}:#{attr_val}" member ..
-    redis.call('srem', model .. ':' .. attr_key .. ':' .. attr_val, id)
+    redis.call('srem', model .. ':' .. attr_key .. ':' .. attr_val .. hash_tag, id)
   end
 end
 
 -- Move an id from one id set to another for the index attribute
-local function replace_id_in_index_attr(model, attr_key, prev_attr_val,curr_attr_val, id)
+local function replace_id_in_index_attr(hash_tag, model, attr_key, prev_attr_val,curr_attr_val, id)
   -- If previous and new value differs, then modify the id sets accordingly
   if prev_attr_val ~= curr_attr_val then
-    delete_id_from_index_attr(model, attr_key, prev_attr_val, id)
-    add_id_to_index_attr(model, attr_key, curr_attr_val, id)
+    delete_id_from_index_attr(hash_tag, model, attr_key, prev_attr_val, id)
+    add_id_to_index_attr(hash_tag, model, attr_key, curr_attr_val, id)
   end
 end
 
 -- Add an id to the sorted id set of the range index attribute
-local function add_id_to_range_index_attr(model, attr_key, attr_val, id)
+local function add_id_to_range_index_attr(hash_tag, model, attr_key, attr_val, id)
   if attr_val then
     -- Nil values of range indices are sent to Redis as an empty string. They are stored
     -- as a regular set at key "#{Model.name}:#{attr_name}:"
     if attr_val == "" then
-      redis.call('sadd', model .. ':' .. attr_key .. ':' .. attr_val, id)
+      redis.call('sadd', model .. ':' .. attr_key .. ':' .. attr_val .. hash_tag, id)
     else
       -- Call the Redis command: ZADD "#{Model.name}:#{attr_name}" #{attr_val} member ..,
       -- where attr_val is the score of the sorted set
-      redis.call('zadd', model .. ':' .. attr_key, attr_val, id)
+      redis.call('zadd', model .. ':' .. attr_key .. hash_tag, attr_val, id)
     end
   end
 end
 
 -- Remove an id from the sorted id set of the range index attribute
-local function delete_id_from_range_index_attr(model, attr_key, attr_val, id)
+local function delete_id_from_range_index_attr(hash_tag, model, attr_key, attr_val, id)
   if attr_val then
     -- Nil values of range indices are sent to Redis as an empty string. They are stored
     -- as a regular set at key "#{Model.name}:#{attr_name}:"
     if attr_val == "" then
-      redis.call('srem', model .. ':' .. attr_key .. ':' .. attr_val, id)
+      redis.call('srem', model .. ':' .. attr_key .. ':' .. attr_val .. hash_tag, id)
     else
       -- Call the Redis command: ZREM "#{Model.name}:#{attr_name}:#{attr_val}" member ..
-      redis.call('zrem', model .. ':' .. attr_key, id)
+      redis.call('zrem', model .. ':' .. attr_key .. hash_tag, id)
     end
   end
 end
 
 -- Move an id from one sorted id set to another for the range index attribute
-local function replace_id_in_range_index_attr(model, attr_key, prev_attr_val, curr_attr_val, id)
+local function replace_id_in_range_index_attr(hash_tag, model, attr_key, prev_attr_val, curr_attr_val, id)
   if prev_attr_val ~= curr_attr_val then
-    delete_id_from_range_index_attr(model, attr_key, prev_attr_val, id)
-    add_id_to_range_index_attr(model, attr_key, curr_attr_val, id)
+    delete_id_from_range_index_attr(hash_tag, model, attr_key, prev_attr_val, id)
+    add_id_to_range_index_attr(hash_tag, model, attr_key, curr_attr_val, id)
   end
 end

--- a/lib/redcord/server_scripts/shared/lua_helper_methods.erb.lua
+++ b/lib/redcord/server_scripts/shared/lua_helper_methods.erb.lua
@@ -1,9 +1,8 @@
 -- Helper function to convert argument array to hash set
-local function to_hash(list)
+local function to_hash(...)
   local hash = {}
-  if not list then return hash end
-  for i=1, #list, 2 do
-    hash[list[i]] = list[i+1]
+  for i=1, #arg, 2 do
+    hash[arg[i]] = arg[i+1]
   end
   return hash
 end

--- a/lib/redcord/server_scripts/shared/query_helper_methods.erb.lua
+++ b/lib/redcord/server_scripts/shared/query_helper_methods.erb.lua
@@ -83,7 +83,7 @@ local function validate_and_parse_query_conditions(model, args)
   -- indexed id sets are stored.
   local index_sets, range_index_sets = {}, {}
   local i = 2
-  while i <= #args do
+  while i + 1 <= #args do
     local attr_key, attr_val = args[i], args[i+1]
     if index_attrs[attr_key] then
       validate_attr_vals(attr_key, {attr_val})

--- a/lib/redcord/server_scripts/update_hash.erb.lua
+++ b/lib/redcord/server_scripts/update_hash.erb.lua
@@ -16,22 +16,22 @@ nil
 -- accessed by Lua using the ARGV global variable, very similarly to what
 -- happens with keys (so ARGV[1], ARGV[2], ...).
 --
---   KEYS[1] = redcord_instance.class.name
---   KEYS[2] = redcord_instance.id
---   KEYS[3] = hash_tag
---   ARGV[1...2N] = attr_key attr_val [attr_key attr_val ..]
+--   KEYS = redcord_instance.id hash_tag
+--   ARGV = Model.name ttl index_attr_size range_index_attr_size [index_attr_key ...] [range_index_attr_key ...] attr_key attr_val [attr_key attr_val ..]
 <%= include_lua 'shared/lua_helper_methods' %>
 <%= include_lua 'shared/index_helper_methods' %>
 
-if #KEYS ~= 3 then
-  error('Expected keys of be of size 3')
-end
-if #ARGV % 2 ~= 0 then
-  error('Expected an even number of arguments')
+if #KEYS ~= 2 then
+  error('Expected keys of be of size 2')
 end
 
-local model = KEYS[1]
-local id = KEYS[2]
+local model, ttl = unpack(ARGV)
+local id, hash_tag = unpack(KEYS)
+
+local index_attr_pos = 5
+local range_attr_pos = index_attr_pos + ARGV[3]
+-- Starting position of the attr_key-attr_val pairs
+local attr_pos = range_attr_pos + ARGV[4]
 
 -- key = "#{model}:id:{id}"
 local key = model .. ':id:' .. id
@@ -45,8 +45,8 @@ if redis.call('exists', key) == 0 then
 end
 
 -- Modify the id sets for any indexed attributes
-local attrs_hash = to_hash(ARGV)
-local indexed_attr_keys = redis.call('smembers', model .. ':index_attrs')
+local attrs_hash = to_hash(unpack(ARGV, attr_pos))
+local indexed_attr_keys = {unpack(ARGV, index_attr_pos, range_attr_pos - 1)}
 if #indexed_attr_keys > 0 then
   -- Get the previous and new values for indexed attributes
   local prev_attrs = redis.call('hmget', key, unpack(indexed_attr_keys))
@@ -54,11 +54,11 @@ if #indexed_attr_keys > 0 then
     local prev_attr_val, curr_attr_val = prev_attrs[i], attrs_hash[attr_key]
     -- Skip attr values not present in the argument hash
     if curr_attr_val then
-      replace_id_in_index_attr(model, attr_key, prev_attr_val, curr_attr_val, id)
+      replace_id_in_index_attr(hash_tag, model, attr_key, prev_attr_val, curr_attr_val, id)
     end
   end
 end
-local range_index_attr_keys = redis.call('smembers', model .. ':range_index_attrs')
+local range_index_attr_keys = {unpack(ARGV, range_attr_pos, attr_pos - 1)}
 if #range_index_attr_keys > 0 then
   -- Get the previous and new values for indexed attributes
   local prev_attrs = redis.call('hmget', key, unpack(range_index_attr_keys))
@@ -66,27 +66,23 @@ if #range_index_attr_keys > 0 then
     local prev_attr_val, curr_attr_val = prev_attrs[i], attrs_hash[attr_key]
     -- Skip attr values not present in the argument hash
     if curr_attr_val then
-      replace_id_in_range_index_attr(model, attr_key, prev_attr_val, curr_attr_val, id)
+      replace_id_in_range_index_attr(hash_tag, model, attr_key, prev_attr_val, curr_attr_val, id)
     end
   end
 end
 
 -- Forward the script arguments to the Redis command HSET and update the args.
 -- Call the Redis command: HSET key [field value ...]
-redis.call('hset', key, unpack(ARGV))
+redis.call('hset', key, unpack(ARGV, attr_pos))
 
 -- Call the Redis command: GET "#{Model.name}:ttl"
-local ttl = redis.call('get', model .. ':ttl')
-
-if ttl then
-  if ttl == '-1' then
-    -- Persist the object if the ttl is set to -1
-    redis.call('persist', key)
-  else
-    -- Reset the TTL for this object. We do this manually becaues altering the
-    -- field value of a hash with HSET, etc. will leave the TTL
-    -- untouched: https://redis.io/commands/expire
-    redis.call('expire', key, ttl)
-  end
+if ttl == '-1' then
+  -- Persist the object if the ttl is set to -1
+  redis.call('persist', key)
+else
+  -- Reset the TTL for this object. We do this manually becaues altering the
+  -- field value of a hash with HSET, etc. will leave the TTL
+  -- untouched: https://redis.io/commands/expire
+  redis.call('expire', key, ttl)
 end
 return nil

--- a/lib/redcord/server_scripts/update_hash.erb.lua
+++ b/lib/redcord/server_scripts/update_hash.erb.lua
@@ -18,12 +18,13 @@ nil
 --
 --   KEYS[1] = redcord_instance.class.name
 --   KEYS[2] = redcord_instance.id
+--   KEYS[3] = hash_tag
 --   ARGV[1...2N] = attr_key attr_val [attr_key attr_val ..]
 <%= include_lua 'shared/lua_helper_methods' %>
 <%= include_lua 'shared/index_helper_methods' %>
 
-if #KEYS ~= 2 then
-  error('Expected keys of be of size 2')
+if #KEYS ~= 3 then
+  error('Expected keys of be of size 3')
 end
 if #ARGV % 2 ~= 0 then
   error('Expected an even number of arguments')

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -61,6 +61,14 @@ describe Redcord::Actions do
         instance.update!(value: '4')
       }.to raise_error(TypeError)
 
+
+      if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+        # Cannot update shard_by attribute
+        expect {
+          instance.update!(indexed_value: 4)
+        }.to raise_error(RuntimeError)
+      end
+
       instance.update!(value: 4)
       expect(instance.value).to eq 4
 
@@ -136,6 +144,9 @@ describe Redcord::Actions do
       non_existing_id = 1
 
       expect {
+        # CLUSTERDOWN is thrown occasionally on CI when a key does not exist.
+        # The cause of this behavior is currently unknown but likely due to the
+        # CI envrionment.
         begin
           klass.find(non_existing_id)
         rescue Redis::CommandError => e

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -10,6 +10,10 @@ describe Redcord::Actions do
       attribute :value, T.nilable(Integer)
       attribute :indexed_value, T.nilable(Integer), index: true
 
+      if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+        shard_by_attribute :indexed_value
+      end
+
       def self.name
         'RedcordSpecModel'
       end
@@ -103,14 +107,12 @@ describe Redcord::Actions do
       instance = klass.create!(value: 3)
 
       klass.ttl(2.days)
-      migrator.change_ttl_passive(klass)
       expect(klass.redis.ttl(instance.instance_key)).to eq(-1)
 
       instance.save!
       expect(klass.redis.ttl(instance.instance_key) > 0).to be true
 
       klass.ttl(nil)
-      migrator.change_ttl_passive(klass)
       instance.update!(value: 4)
       expect(klass.redis.ttl(instance.instance_key)).to eq(-1)
     end

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -34,14 +34,12 @@ describe Redcord::Actions do
       klass.create!(value: '1')
     end
 
-    it 'errors when id overflows a 64 bit signed integer' do
-      Redcord::Base.redis.set("#{klass.model_key}:id_seq", 2**63 - 2)
-
-      instance = klass.create!(value: nil)
-      expect(instance.id).to eq(2**63 - 1)
+    it 'errors when uuids collide' do
+      allow(SecureRandom).to receive(:uuid).and_return('fixed')
+      klass.create!(value: '1')
 
       expect {
-        klass.create!(value: nil)
+        klass.create!(value: '1')
       }.to raise_error(Redis::CommandError)
     end
   end
@@ -142,11 +140,6 @@ describe Redcord::Actions do
       instance = klass.create!(value: 1)
 
       another_instance = klass.find(instance.id)
-
-      # It validates types
-      expect {
-        klass.find(another_instance.id.to_s)
-      }.to raise_error(TypeError)
 
       expect(another_instance.id).to eq instance.id
       expect(another_instance.value).to eq instance.value

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -136,7 +136,16 @@ describe Redcord::Actions do
       non_existing_id = 1
 
       expect {
-        klass.find(non_existing_id)
+        begin
+          klass.find(non_existing_id)
+        rescue Redis::CommandError => e
+          if e.message != 'CLUSTERDOWN The cluster is down'
+            raise e
+          end
+
+          sleep(0.5)
+          retry
+        end
       }.to raise_error(Redcord::RecordNotFound)
 
       instance = klass.create!(value: 1)

--- a/spec/migration/index_spec.rb
+++ b/spec/migration/index_spec.rb
@@ -5,7 +5,7 @@
 describe Redcord::Migration::Index do
   include Redcord::Migration::Index
 
-  xit 'drops an index' do
+  it 'drops an index' do
     klass = Class.new(T::Struct) do
       include Redcord::Base
 

--- a/spec/migration/index_spec.rb
+++ b/spec/migration/index_spec.rb
@@ -12,6 +12,10 @@ describe Redcord::Migration::Index do
       attribute :index, T.nilable(String), index: true
       attribute :range_index, T.nilable(Integer), index: true
 
+      if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+        shard_by_attribute :index
+      end
+
       def self.name
         'RedcordSpecModel'
       end
@@ -19,7 +23,7 @@ describe Redcord::Migration::Index do
     klass.establish_connection
 
     k = klass.create!(range_index: 1, index: '123')
-    expect(klass.find_by(range_index: 1).id).to eq k.id
+    expect(klass.find_by(index: '123', range_index: 1).id).to eq k.id
     expect(klass.find_by(index: '123').id).to eq k.id
 
     klass = Class.new(T::Struct) do
@@ -27,6 +31,12 @@ describe Redcord::Migration::Index do
 
       attribute :index, T.nilable(String)
       attribute :range_index, T.nilable(Integer)
+
+      if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+        attribute :new_index, T.nilable(String), index: true
+
+        shard_by_attribute :new_index
+      end
 
       def self.name
         'RedcordSpecModel'

--- a/spec/migration/index_spec.rb
+++ b/spec/migration/index_spec.rb
@@ -5,7 +5,7 @@
 describe Redcord::Migration::Index do
   include Redcord::Migration::Index
 
-  it 'drops an index' do
+  xit 'drops an index' do
     klass = Class.new(T::Struct) do
       include Redcord::Base
 
@@ -33,11 +33,6 @@ describe Redcord::Migration::Index do
       end
     end
     klass.establish_connection
-
-    # Still using the previous index before running migrations
-    klass.create!(range_index: 1, index: '321')
-    expect(klass.redis.exists?("#{klass.model_key}:index:321")).to be true
-    expect(klass.redis.exists?("#{klass.model_key}:range_index")).to be true
 
     expect {
       klass.find_by(index: '123').id

--- a/spec/migration/migrator_spec.rb
+++ b/spec/migration/migrator_spec.rb
@@ -39,12 +39,12 @@ describe Redcord::Migration::Migrator do
 
   let!(:migration_path) { 'db/redcord/migrate' }
   let!(:migration_version) { '20200504000000' }
-  let!(:migration_filename) { "#{migration_version}_set_user_session_ttl.rb" }
+  let!(:migration_filename) { "#{migration_version}_test_migration.rb" }
   let!(:migration_content) do
     <<~RUBY
-      class SetUserSessionTtl < Redcord::Migration
+      class TestMigration < Redcord::Migration
         def up
-          change_ttl_passive(UserSession) # 14.days
+         
         end
 
         def down
@@ -79,7 +79,7 @@ describe Redcord::Migration::Migrator do
       Rake::Task['redis:migrate'].invoke
     }.to output(%r{
       redis\s+direction\s+version\s+migration\s+duration\s+
-      redis://127\.0\.0\.1:6379/0\s+
+      redis://.+\s+
       UP\s+
       #{migration_version}\s+
     }x).to_stdout

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -92,7 +92,7 @@ describe Redcord::Serializer do
         klass.where(
           a: Redcord::RangeInterval.new(max: 3, max_exclusive: true),
         ).count
-      }.to raise_error(RuntimeError)
+      }.to raise_error(Redcord::WrongAttributeType)
     else
       queried_instances = klass.where(
         a: Redcord::RangeInterval.new(max: 3, max_exclusive: true),

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -143,7 +143,7 @@ describe Redcord::Serializer do
     # query with one attribute should return both values
     queried_instances = klass.where(a: 3)
     expect(queried_instances.size).to eq 2
-    expect(queried_instances.map(&:id)).to eq([first.id, second.id])
+    expect(queried_instances.map(&:id).sort).to eq([first.id, second.id].sort)
 
     queried_instances = klass.where(a: 3, b: '3')
     expect(queried_instances.size).to eq 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Redcord::Base.redis.flushdb
-    Redcord::PreparedRedis.load_server_scripts!
+    Redcord::Redis.load_server_scripts!
     Redcord.establish_connections
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Redcord::Base.redis.flushdb
-    Redcord::Redis.load_server_scripts!
     Redcord.establish_connections
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'simplecov'
+require 'open3'
 
 SimpleCov.start
 
@@ -13,7 +14,109 @@ RSpec.configure do |config|
 
   Time.zone = 'UTC'
 
+  def create_redis_cluster(num_nodes:)
+    docker_network = 'redcord_spec_redis_cluster'
+    cluster_node_port = 7000
+
+    run_system_command(
+      "docker network create #{docker_network}",
+      # network maybe already exists
+      allow_failure: true,
+    )
+
+    node_ips = []
+
+    `docker container ls -a`.split("\n").each do |container|
+      container_id = container.match(/(\w*)\s+.*redcord-spec-redis-node-\d+$/)&.send(:[], 1)
+      if container_id
+        run_system_command(
+          "docker container rm #{container_id} -f",
+          allow_failure: true,
+        )
+      end
+    end
+
+    File.open('redcord_spec_redis_cluster.config', 'w') do |f|
+      f << <<~CONFIG
+        port #{cluster_node_port}
+        cluster-enabled yes
+        cluster-config-file nodes.conf
+        cluster-node-timeout 5000
+        appendonly yes
+      CONFIG
+      f.flush
+
+
+      node_ips = (1..num_nodes).map do |i|
+        node_id = "redcord-spec-redis-node-#{i}"
+        cmd = <<~CMD
+          docker run -d \
+            -v #{File.expand_path(f.path)}:/usr/local/etc/redis/redis.conf \
+            --name #{node_id} \
+            --net #{docker_network} \
+            redis redis-server /usr/local/etc/redis/redis.conf
+        CMD
+
+        puts run_system_command(
+          cmd,
+          # network maybe already exists
+          allow_failure: true,
+        )
+        cmd = <<~CMD
+          docker inspect \
+            -f '{{ (index .NetworkSettings.Networks "#{docker_network}").IPAddress }}' #{node_id}
+        CMD
+        ip, _ = run_system_command(cmd)
+        ip.chomp
+      end
+      puts "Creating a Redis cluster using nodes: #{node_ips}"
+
+      cmd = <<~CMD
+        docker run -i --rm \
+          --net #{docker_network} \
+          redis sh -c 'redis-cli --cluster create #{
+            node_ips.map { |ip| "#{ip}:#{cluster_node_port}" }.join(' ')
+          } --cluster-yes'
+      CMD
+      run_system_command(cmd, allow_failure: true)
+    end
+
+    Redis.new(cluster: node_ips.map { |ip| "redis://#{ip}:#{cluster_node_port}" })
+  end
+
+  def run_system_command(cmd, allow_failure: false)
+    puts "> #{cmd}"
+    stdout, stderr, status = Open3.capture3(cmd)
+
+    if !allow_failure
+      $stderr.puts stderr
+    end
+
+    if !status.success? && !allow_failure
+      exit status.exitstatus
+    end
+
+    [stdout, stderr]
+  end
+
+  if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+    Redcord::Base.redis = create_redis_cluster(num_nodes: 3)
+  end
+
   config.before(:each) do
+    if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+      allow(Rails).to receive(:env).and_return('test')
+      allow(Redcord::Base).to receive(:configurations).and_return(
+        {
+          'test' => {
+            'default' => {
+              'cluster' => $redcord_redis_cluster,
+            },
+          },
+        },
+      )
+    end
+
     Redcord::Base.redis.flushdb
     Redcord.establish_connections
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,7 +81,7 @@ RSpec.configure do |config|
       run_system_command(cmd, allow_failure: true)
     end
 
-    Redis.new(cluster: node_ips.map { |ip| "redis://#{ip}:#{cluster_node_port}" })
+    node_ips.map { |ip| "redis://#{ip}:#{cluster_node_port}" }
   end
 
   def run_system_command(cmd, allow_failure: false)
@@ -100,7 +100,7 @@ RSpec.configure do |config|
   end
 
   if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
-    Redcord::Base.redis = create_redis_cluster(num_nodes: 3)
+    $redcord_redis_cluster = create_redis_cluster(num_nodes: 3)
   end
 
   config.before(:each) do

--- a/spec/vacuum_spec.rb
+++ b/spec/vacuum_spec.rb
@@ -8,6 +8,10 @@ describe Redcord::VacuumHelper do
 
     attribute :a, T.nilable(String), index: true
     attribute :b, T.nilable(Integer), index: true
+
+    if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+      shard_by_attribute :a
+    end
   end
 
   let (:model_key) { RedcordVacuumSpecModel.model_key }
@@ -17,10 +21,10 @@ describe Redcord::VacuumHelper do
       instance = RedcordVacuumSpecModel.create!(a: "x", b: 1)
       # index sets should contain the id
       expect(
-        RedcordVacuumSpecModel.redis.sismember("#{model_key}:a:#{instance.a}", instance.id)
+        RedcordVacuumSpecModel.redis.sismember("#{model_key}:a:#{instance.a}#{instance.hash_tag}", instance.id)
       ).to be true
       expect(
-        RedcordVacuumSpecModel.redis.zscore("#{model_key}:b", instance.id)
+        RedcordVacuumSpecModel.redis.zscore("#{model_key}:b#{instance.hash_tag}", instance.id)
       ).to eq 1
 
        # An expired record due to TTL
@@ -28,21 +32,21 @@ describe Redcord::VacuumHelper do
 
       # After vacuuming, index sets should be updated
       Redcord::VacuumHelper.vacuum(RedcordVacuumSpecModel)
-      expect(RedcordVacuumSpecModel.redis.sismember("#{model_key}:a:#{instance.a}", instance.id)).to be false
-      expect(RedcordVacuumSpecModel.redis.zscore("#{model_key}:b", instance.id)).to be_nil
+      expect(RedcordVacuumSpecModel.redis.sismember("#{model_key}:a:#{instance.a}#{instance.hash_tag}", instance.id)).to be false
+      expect(RedcordVacuumSpecModel.redis.zscore("#{model_key}:b#{instance.hash_tag}", instance.id)).to be_nil
     end
 
     it 'vacuums range index attributes with nil values' do
       instance = RedcordVacuumSpecModel.create!(b: nil)
       # The nil range index set should contain the id
-      expect(RedcordVacuumSpecModel.redis.sismember("#{model_key}:b:", instance.id)).to be true
+      expect(RedcordVacuumSpecModel.redis.sismember("#{model_key}:b:#{instance.hash_tag}", instance.id)).to be true
 
       # An expired record due to TTL
       RedcordVacuumSpecModel.redis.del("#{model_key}:id:#{instance.id}")
 
       # After vacuuming, nil range index set should be updated
       Redcord::VacuumHelper.vacuum(RedcordVacuumSpecModel)
-      expect(RedcordVacuumSpecModel.redis.sismember("#{model_key}:b:", instance.id)).to be false
+      expect(RedcordVacuumSpecModel.redis.sismember("#{model_key}:b:#{instance.hash_tag}", instance.id)).to be false
     end
   end
 end


### PR DESCRIPTION
This implements sharding to split big index keys among different redis server nodes.

- Use random UUID (because id_seq cannot be synced across servers)
- Create a new record using a hash_tag

### Test Plan
- [x] Confirm adding new nodes will linearly decrease the engine CPU usage
- [x] Confirm operations have much higher throughput
