### PR TITLE
Make float attr round-trippable

### DIFF
--- a/lib/redcord/serializer.rb
+++ b/lib/redcord/serializer.rb
@@ -34,7 +34,12 @@ module Redcord::Serializer
         val = val.to_f
       end
 
-      val
+      if val.is_a?(Float)
+        # Encode as round-trippable float64
+        '%1.16e' % [val]
+      else
+        val
+      end
     end
 
     sig { params(attribute: Symbol, val: T.untyped).returns(T.untyped) }

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -62,6 +62,13 @@ describe Redcord::Serializer do
       a: 3,
       float: Redcord::RangeInterval.new(min: 4.0)),
     ).to be_nil
+
+    # round trip
+    klass.create!(a: 3, b: '3', c: 3, float: 1.0 / 3.0)
+    expect(klass.find_by(
+      a: 3,
+      float: 1.0 / 3.0,
+    )).to_not be_nil
   end
 
   context 'when query is invalid' do


### PR DESCRIPTION
When reviewing #72, I noticed currently we don't precisely send a float64 to redis; so currently they're not precisely stored on redis (suffer from precision loss).

### Test Plan
- [x] Added a test case to ensure floats are round-trippable