### PR TITLE
[feature] Model#save

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Once a Redcord object has been retrieved, its attributes can be modified and it 
 ```ruby
 user_session = UserSession.find_by(user_id: user.id)
 user_session.updated_at = Time.zone.now
-user_session.save # TODO: support this
+user_session.save
 ```
 
 A shorthand for this is to use a hash mapping attribute names to the desired value:

--- a/lib/redcord/actions.rb
+++ b/lib/redcord/actions.rb
@@ -163,6 +163,16 @@ module Redcord::Actions
       end
     end
 
+    sig { returns(T::Boolean) }
+    def save
+      save!
+
+      true
+    rescue Redis::CommandError
+      # TODO: break down Redis::CommandError by parsing the error message
+      false
+    end
+
     sig { params(args: T::Hash[Symbol, T.untyped]).void }
     def update!(args = {})
       Redcord::Base.trace(

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -102,6 +102,12 @@ describe Redcord::Actions do
       expect(instance.value).to eq another_instance.value
     end
 
+    it '#save' do
+      instance = klass.create!(value: 3, indexed_value: 1)
+      instance.destroy # e.g. the record is destroyed by another process
+      expect(instance.save).to be false
+    end
+
     it 'doesn\'t update redis until save!/update! is called' do
       instance = klass.create!(value: 3)
       instance.value = 4


### PR DESCRIPTION
This implements Model#save, a non-raise version of save!. This API is identical to Rails activerecord.

### Test Plan
- [x] Added a test case to cover this behavior