### PR TITLE
Make time attr round-trippable

### DIFF
--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -202,8 +202,8 @@ describe Redcord::Actions do
       another_instance = klass.find(instance.id)
       expect(another_instance.id).to eq instance.id
       expect(another_instance.value).to eq instance.value
-      expect(another_instance.created_at.to_i).to eq instance.created_at.to_i
-      expect(another_instance.updated_at.to_i).to eq instance.updated_at.to_i
+      expect(another_instance.created_at).to eq instance.created_at
+      expect(another_instance.updated_at).to eq instance.updated_at
 
       instance.destroy
 

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -33,10 +33,21 @@ describe Redcord::Serializer do
     another_instance = klass.find_by(a: 3)
 
     expect(instance.d).to be_nil
-    expect(instance.created_at.to_i).to eq(now.to_i)
-    expect(instance.updated_at.to_i).to eq(now.to_i)
-    expect(instance.created_at.to_i).to eq(another_instance.created_at.to_i)
-    expect(instance.updated_at.to_i).to eq(another_instance.updated_at.to_i)
+    expect(instance.created_at).to eq(now)
+    expect(instance.updated_at).to eq(now)
+    expect(instance.created_at).to eq(another_instance.created_at)
+    expect(instance.updated_at).to eq(another_instance.updated_at)
+
+    now = Time.zone.at(-1000)
+    allow(Time.zone).to receive(:now).and_return(now)
+    allow(Time).to receive(:now).and_return(now)
+
+    instance = klass.create!(a: 4, b: '4', c: 4)
+    another_instance = klass.find_by(a: 4)
+    expect(instance.created_at).to eq(now)
+    expect(instance.updated_at).to eq(now)
+    expect(instance.created_at).to eq(another_instance.created_at)
+    expect(instance.updated_at).to eq(another_instance.updated_at)
   end
 
   it 'works with boolean types' do


### PR DESCRIPTION
https://apidock.com/ruby/Time/nsec
> The lowest digits of #to_f and #nsec are different because IEEE 754 double is not accurate enough to represent the exact number of nanoseconds since the Epoch.

> The more accurate value is returned by #nsec.

This converts time from a float to integer so it can become round-trippable.

**This is a breaking change!** The existing records are not compatible with the new version.

### Test Plan
- [x] Modified test cases to cover this behavior