### PR TITLE
Skip maintaining index for shard_by_attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ class UserSession < T::Struct
   attribute :user_id, Integer, index: true
   attribute :session_id, String
 
-  attribute :region, String, index: true
+  attribute :region, String
   shard_by_attribute :region
 end
 ```
@@ -174,8 +174,9 @@ production:
 Constraints:
 1. The sharded attribute cannot be updated
 2. All queries must have the sharded attribute as a query condition
-3. Only equality query conditions are allowed on the sharded attribute: `UserSession.where(region: 'u.s.', ...)`
-4. Operations cannot be atomic if they operate on different shards
+3. The sharded attribute cannot be queried alone: `UserSession.where(region: 'u.s.') # error: Redcord::InvalidQuery`
+4. Only equality query conditions are allowed on the sharded attribute: `UserSession.where(region: 'u.s.', ...)`
+5. Operations cannot be atomic if they operate on different shards
 
 ### 8. Monitoring
 Redcord reports metrics to a tracer (for example, [Datadog APM](https://docs.datadoghq.com/tracing/setup/ruby/#manual-instrumentation)) if it is configured.

--- a/lib/redcord/actions.rb
+++ b/lib/redcord/actions.rb
@@ -9,6 +9,7 @@ require 'redcord/relation'
 module Redcord
   # Raised by Model.find
   class RecordNotFound < StandardError; end
+  class InvalidAction < StandardError; end
 end
 
 module Redcord::Actions
@@ -188,9 +189,9 @@ module Redcord::Actions
        'redcord_actions_instance_methods_update!',
         model_name: self.class.name,
       ) do
-        shard_by_attr = self.class.class_variable_get(:@@shard_by_attribute)
+        shard_by_attr = self.class.shard_by_attribute
         if args.keys.include?(shard_by_attr)
-          raise "Cannot update shard_by attribute #{shard_by_attr}"
+          raise Redcord::InvalidAction, "Cannot update shard_by attribute #{shard_by_attr}"
         end
 
         _id = id

--- a/lib/redcord/serializer.rb
+++ b/lib/redcord/serializer.rb
@@ -59,7 +59,7 @@ module Redcord::Serializer
     def validate_types_and_encode_query(attr_key, attr_val)
       # Validate attribute types for index attributes
       attr_type = get_attr_type(attr_key)
-      if class_variable_get(:@@index_attributes).include?(attr_key)
+      if class_variable_get(:@@index_attributes).include?(attr_key) || attr_key == shard_by_attribute
         validate_attr_type(attr_val, attr_type)
       else
         validate_range_attr_types(attr_val, attr_type)
@@ -79,6 +79,8 @@ module Redcord::Serializer
     def validate_index_attributes(attr_keys, custom_index_name: nil)
       custom_index_attributes = class_variable_get(:@@custom_index_attributes)[custom_index_name]
       attr_keys.each do |attr_key|
+        next if attr_key == shard_by_attribute
+
         if !custom_index_attributes.empty?
           if !custom_index_attributes.include?(attr_key)
             raise(

--- a/spec/attribute_spec.rb
+++ b/spec/attribute_spec.rb
@@ -61,7 +61,7 @@ describe Redcord::Attribute do
       Class.new(T::Struct) do
         include Redcord::Base
         attribute :a, Integer
-        attribute :b, Integer, index: true
+        attribute :b, Integer
         custom_index :main, [:a, :b]
         shard_by_attribute :b
       end
@@ -71,7 +71,7 @@ describe Redcord::Attribute do
       Class.new(T::Struct) do
         include Redcord::Base
         attribute :a, Integer
-        attribute :b, Integer, index: true
+        attribute :b, Integer
         custom_index :main, [:b, :a]
         shard_by_attribute :b
       end
@@ -83,7 +83,7 @@ describe Redcord::Attribute do
       Class.new(T::Struct) do
         include Redcord::Base
         attribute :a, Integer
-        attribute :b, Integer, index: true
+        attribute :b, Integer
         shard_by_attribute :b
         custom_index :main, [:a, :b]
       end
@@ -97,7 +97,7 @@ describe Redcord::Attribute do
         shard_by_attribute :b
         custom_index :main, [:b, :a]
       end
-    }.to_not raise_error()
+    }.to raise_error(Redcord::InvalidAttribute) # attr b should not be indexed
   end
 
   it 'validates custom index attributes have allowed type' do

--- a/spec/custom_index_spec.rb
+++ b/spec/custom_index_spec.rb
@@ -9,11 +9,12 @@ describe "Custom index" do
 
       attribute :value, T.nilable(Integer)
       attribute :time_value, T.nilable(Time)
-      attribute :indexed_value, T.nilable(Integer), index: true
+      attribute :indexed_value, T.nilable(Integer), index: !cluster_mode?
       attribute :other_value, T.nilable(Integer), index: true
       custom_index :first, [:indexed_value, :time_value, :value]
       custom_index :second, [:indexed_value, :other_value]
-      if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+
+      if cluster_mode?
         shard_by_attribute :indexed_value
       else
         custom_index :non_cluster_index, [:time_value]
@@ -34,18 +35,31 @@ describe "Custom index" do
 
     it 'raises an error when negative value is used for custom index attr' do
       # shared/lua_helper_methods.erb.lua: adjust_string_length
-      expect { klass.create!(indexed_value: -1) }.to raise_error(Redis::CommandError)
+      expect { klass.create!(value: -1) }.to raise_error(Redis::CommandError)
+
+      if cluster_mode?
+        # shared_by_attr is not actually part of the custom index
+        klass.create!(indexed_value: -1)
+      else
+        expect { klass.create!(indexed_value: -1) }.to raise_error(Redis::CommandError)
+      end
     end
 
     it 'raises an error when large numbers (more than 19 digits in decimal notation) used in custom index' do
-      # shared/lua_helper_methods.erb.lua: adjust_string_length
-      expect { klass.create!(indexed_value: 10**19) }.to raise_error(Redis::CommandError)
+      if cluster_mode?
+        # shared_by_attr is not actually part of the custom index
+        klass.create!(indexed_value: 10**19)
+      else
+        # shared/lua_helper_methods.erb.lua: adjust_string_length
+        expect { klass.create!(indexed_value: 10**19) }.to raise_error(Redis::CommandError)
+      end
+
       expect { klass.create!(indexed_value: 10**19 - 1) }.to_not raise_error()
     end
 
     it 'raises an error when inexisting custom index is queried' do
       # shared/query_helper_methods.erb.lua: validate_and_parse_query_conditions_custom
-      expect { klass.where(indexed_value: 1).with_index(:third).to_a }.to raise_error(Redis::CommandError)
+      expect { klass.where(indexed_value: 1, other_value: 2).with_index(:third).to_a }.to raise_error(Redis::CommandError)
     end
 
     it 'raises error when range query conditions are used not on the last attribute in a query' do
@@ -64,8 +78,7 @@ describe "Custom index" do
     end
 
     it 'sorts conditions in correct order for custom index' do
-      interval = Redcord::RangeInterval.new(min: time_now - 10.seconds)
-      rel = klass.where(time_value: interval, indexed_value: 1).with_index(:first)
+      rel = klass.where(value: instance.value, time_value: instance.time_value, indexed_value: instance.indexed_value).with_index(:first)
       expect(rel.count).to eq(1)
       expect(rel.to_a.size).to eq(1)
     end
@@ -90,25 +103,23 @@ describe "Custom index" do
       end
       expect(index_string_exists).to be(true)
     end
-    
-    it 'returns instance by int attribute query' do
-      expect(klass.where(indexed_value: 1).with_index(:first).to_a.first.id).to eq(instance.id)
-    end
 
-    it 'returns count by int attribute query' do
-      expect(klass.where(indexed_value: 1).with_index(:first).count).to eq(1)
-      expect(klass.where(indexed_value: 3).with_index(:first).count).to eq(0)
-    end
+    unless cluster_mode?
+      it 'returns instance by int attribute query' do
+        expect(klass.where(indexed_value: 1).with_index(:first).to_a.first.id).to eq(instance.id)
+      end
 
-    it 'returns instance by time attribute range query' do
-      interval = Redcord::RangeInterval.new(min: time_now - 10.seconds)
-      unless ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+      it 'returns count by int attribute query' do
+        expect(klass.where(indexed_value: 1).with_index(:first).count).to eq(1)
+        expect(klass.where(indexed_value: 3).with_index(:first).count).to eq(0)
+      end
+
+      it 'returns instance by time attribute range query' do
+        interval = Redcord::RangeInterval.new(min: time_now - 10.seconds)
         expect(klass.where(time_value: interval).with_index(:non_cluster_index).to_a.first.id).to eq(instance.id)
       end
-    end
 
-    it 'returns instance by attribute is nil query' do
-      unless ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+      it 'returns instance by attribute is nil query' do
         expect(klass.where(time_value: nil).with_index(:non_cluster_index).to_a.first.id).to eq(instance_2.id)
       end
     end
@@ -123,13 +134,14 @@ describe "Custom index" do
     end
 
     it 'returns selected attributes' do
-      expect(klass.where(indexed_value: 1).with_index(:first).select(:time_value).first[:time_value].to_i).to eq(instance.time_value.to_i)
+      expect(
+        klass.where(indexed_value: 1, time_value: instance.time_value).with_index(:first).select(:time_value).first[:time_value].to_i
+      ).to eq(instance.time_value.to_i)
     end
 
     it 'cleans up custom index after deleting record' do
-      instance_id = instance.id
       instance.destroy
-      expect(klass.where(indexed_value: 1).with_index(:first).count).to eq(0)
+      expect(klass.where(indexed_value: 1, time_value: instance.time_value).with_index(:first).count).to eq(0)
       index_string_exists = false
       klass.redis.scan_each_shard("#{klass.model_key}:custom_index:first_content*") do |key|
         index_string_exists ||= klass.redis.hget(key, instance.id).is_a?(String)
@@ -140,15 +152,18 @@ describe "Custom index" do
     it 'updates custom index on record update' do
       interval = Redcord::RangeInterval.new(min: time_now - 10.seconds)
       expect(klass.where(indexed_value: 2, time_value: interval).with_index(:first).count).to eq(0)
-      expect(klass.where(time_value: interval).with_index(:non_cluster_index).count).to eq(1) unless ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+      expect(klass.where(time_value: interval).with_index(:non_cluster_index).count).to eq(1) unless cluster_mode?
       instance_2.update!(time_value: time_now)
       expect(klass.where(indexed_value: 2, time_value: interval).with_index(:first).count).to eq(1)
-      expect(klass.where(time_value: interval).with_index(:non_cluster_index).count).to eq(2) unless ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+      expect(klass.where(time_value: interval).with_index(:non_cluster_index).count).to eq(2) unless cluster_mode?
     end
 
     it 'retrives results when using query building' do
       rel1 = klass.where(indexed_value: 5)
-      expect(rel1.with_index(:first).to_a.size).to eq(2)
+      unless cluster_mode?
+        expect(rel1.with_index(:first).to_a.size).to eq(2)
+      end
+
       interval = Redcord::RangeInterval.new(min: time_now - 3.hours)
       rel2 = rel1.where(time_value: interval)
       expect(rel2.with_index(:first).to_a.size).to eq(1)
@@ -156,7 +171,10 @@ describe "Custom index" do
 
     it 'allows adding conditions to relations after setting index' do
       rel1 = klass.where(indexed_value: 5).with_index(:first)
-      expect(rel1.count).to eq(2)
+      unless cluster_mode?
+        expect(rel1.count).to eq(2)
+      end
+
       interval = Redcord::RangeInterval.new(min: time_now - 3.hours)
       rel2 = rel1.where(time_value: interval)
       expect(rel2.count).to eq(1)
@@ -177,11 +195,11 @@ describe "Custom index" do
     context 'all attributes are nilable' do
       klass = Class.new(T::Struct) do
         include Redcord::Base
-        attribute :a, T.nilable(Integer), index: true
+        attribute :a, T.nilable(Integer), index: !cluster_mode?
         attribute :b, T.nilable(Integer)
         attribute :c, T.nilable(Integer)
         custom_index :first, [:a, :b, :c]
-        if ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+        if cluster_mode?
           shard_by_attribute :a
         end
 
@@ -191,14 +209,14 @@ describe "Custom index" do
       end
 
       it 'creates and indexes instance with all nil attributes with create!' do
-        unless ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+        unless cluster_mode?
           klass.create!({})
           expect(klass.where(a: nil, b: nil).with_index(:first).count).to eq(1)
         end
       end
 
       it 'creates and indexes instance with all nil attributes with save!' do
-        unless ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+        unless cluster_mode?
           instance = klass.new({})
           instance.save!
           expect(klass.where(a: nil, b: nil).with_index(:first).count).to eq(1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,10 @@ if ENV['CI'] == 'true'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
+def cluster_mode?
+  ENV['REDCORD_SPEC_USE_CLUSTER'] == 'true'
+end
+
 RSpec.configure do |config|
   require 'redcord'
 


### PR DESCRIPTION
Maintaining index sets for shard_by_attr is unnecessary. It's much more performant if we don't have to join it with other indices sets (especially when the other sets are ranged index sets -- we'd perform a loop join in the lua script).

This PR addresses the issue and enforces queries to contain at least 2 query conditions: the shard by attr condition, and another query condition on an indexed attribute (or more conditions).

For custom_index, the first attr (previously the shard_by_attr) is now removed -- the data in the zset for the first attr is the same for all records in the set anyway.