### PR TITLE
[bug] Fix vacuuming models with cluster mode on

### DIFF
--- a/lib/redcord/vacuum_helper.rb
+++ b/lib/redcord/vacuum_helper.rb
@@ -32,24 +32,27 @@ module Redcord::VacuumHelper
 
   sig { params(model: T.class_of(Redcord::Base), range_index_attr: Symbol).void }
   def self._vacuum_range_index_attribute(model, range_index_attr)
+    key_suffix = model.shard_by_attribute.nil? ? nil : '{*}'
     range_index_set_key = "#{model.model_key}:#{range_index_attr}"
     range_index_set_nil_key = "#{range_index_set_key}:"
 
     # Handle nil values for range index attributes, which are stored in a normal
     # set at Redcord:Model:range_index_attr:
-    model.redis.scan_each_shard("#{range_index_set_nil_key}*") do |key|
+    model.redis.scan_each_shard("#{range_index_set_nil_key}#{key_suffix}") do |key|
       _remove_stale_ids_from_set(model, key)
     end
 
-    model.redis.scan_each_shard("#{range_index_set_key}*") do |key|
+    model.redis.scan_each_shard("#{range_index_set_key}#{key_suffix}") do |key|
       _remove_stale_ids_from_sorted_set(model, key)
     end
   end
 
   sig { params(model: T.class_of(Redcord::Base), index_name: Symbol).void }
   def self._vacuum_custom_index(model, index_name)
+    key_suffix = model.shard_by_attribute.nil? ? nil : '{*}'
     custom_index_content_key = "#{model.model_key}:custom_index:#{index_name}_content"
-    model.redis.scan_each_shard("#{custom_index_content_key}*") do |key|
+
+    model.redis.scan_each_shard("#{custom_index_content_key}#{key_suffix}") do |key|
       hash_tag = key.split(custom_index_content_key)[1] || ""
       _remove_stale_records_from_custom_index(model, hash_tag, index_name)
     end

--- a/spec/vacuum_spec.rb
+++ b/spec/vacuum_spec.rb
@@ -12,11 +12,12 @@ describe Redcord::VacuumHelper do
     shard_by_attribute :a if cluster_mode?
   end
 
-  let (:model_key) { RedcordVacuumSpecModel.model_key }
+  let(:model_key) { RedcordVacuumSpecModel.model_key }
 
   context 'vacuum' do
     it 'vacuums all index attributes' do
       instance = RedcordVacuumSpecModel.create!(a: "x", b: 1)
+      RedcordVacuumSpecModel.create!(a: "x", b: nil)
       # index sets should contain the id
       unless cluster_mode?
         expect(


### PR DESCRIPTION
Currently, the wild card matches not only the hast tags, but the nil index sets too when scanning.

### Test Plan
- Added a test case which repros the issue
- ci