### PR TITLE
[bug] Fix tracer with resource tag

### DIFF
--- a/lib/redcord/redis.rb
+++ b/lib/redcord/redis.rb
@@ -18,24 +18,19 @@ class Redcord::Redis < Redis
     ).returns(String)
   end
   def create_hash_returning_id(key, args, ttl:, index_attrs:, range_index_attrs:, custom_index_attrs:, hash_tag: nil)
-    Redcord::Base.trace(
-      'redcord_redis_create_hash_returning_id',
-      model_name: key,
-    ) do
-      id = "#{SecureRandom.uuid}#{hash_tag}"
-      custom_index_attrs_flat = custom_index_attrs.inject([]) do |result, (index_name, attrs)|
-        result << index_name
-        result << attrs.size
-        result + attrs
-      end
-      run_script(
-        :create_hash,
-        keys: [id, hash_tag],
-        argv: [key, ttl, index_attrs.size, range_index_attrs.size, custom_index_attrs_flat.size] + 
-          index_attrs + range_index_attrs + custom_index_attrs_flat + args.to_a.flatten,
-      )
-      id
+    id = "#{SecureRandom.uuid}#{hash_tag}"
+    custom_index_attrs_flat = custom_index_attrs.inject([]) do |result, (index_name, attrs)|
+      result << index_name
+      result << attrs.size
+      result + attrs
     end
+    run_script(
+      :create_hash,
+      keys: [id, hash_tag],
+      argv: [key, ttl, index_attrs.size, range_index_attrs.size, custom_index_attrs_flat.size] +
+        index_attrs + range_index_attrs + custom_index_attrs_flat + args.to_a.flatten,
+    )
+    id
   end
 
   sig do
@@ -51,26 +46,21 @@ class Redcord::Redis < Redis
     ).void
   end
   def update_hash(model, id, args, ttl:, index_attrs:, range_index_attrs:, custom_index_attrs:, hash_tag:)
-    Redcord::Base.trace(
-      'redcord_redis_update_hash',
-      model_name: model,
-    ) do
-      custom_index_attrs_flat = custom_index_attrs.inject([]) do |result, (index_name, attrs)|
-        if !(args.keys.to_set & attrs.to_set).empty?
-          result << index_name
-          result << attrs.size
-          result + attrs
-        else
-          result
-        end
+    custom_index_attrs_flat = custom_index_attrs.inject([]) do |result, (index_name, attrs)|
+      if !(args.keys.to_set & attrs.to_set).empty?
+        result << index_name
+        result << attrs.size
+        result + attrs
+      else
+        result
       end
-      run_script(
-        :update_hash,
-        keys: [id, hash_tag],
-        argv: [model, ttl, index_attrs.size, range_index_attrs.size, custom_index_attrs_flat.size] +
-          index_attrs + range_index_attrs + custom_index_attrs_flat + args.to_a.flatten,
-      )
     end
+    run_script(
+      :update_hash,
+      keys: [id, hash_tag],
+      argv: [model, ttl, index_attrs.size, range_index_attrs.size, custom_index_attrs_flat.size] +
+        index_attrs + range_index_attrs + custom_index_attrs_flat + args.to_a.flatten,
+    )
   end
 
   sig do
@@ -83,17 +73,12 @@ class Redcord::Redis < Redis
     ).returns(Integer)
   end
   def delete_hash(model, id, index_attrs:, range_index_attrs:, custom_index_attrs:)
-    Redcord::Base.trace(
-      'redcord_redis_delete_hash',
-      model_name: model,
-    ) do
-      custom_index_names = custom_index_attrs.keys
-      run_script(
-        :delete_hash,
-        keys: [id, id.match(/\{.*\}$/)&.send(:[], 0)],
-        argv: [model, index_attrs.size, range_index_attrs.size] + index_attrs + range_index_attrs + custom_index_names,
-      )
-    end
+    custom_index_names = custom_index_attrs.keys
+    run_script(
+      :delete_hash,
+      keys: [id, id.match(/\{.*\}$/)&.send(:[], 0)],
+      argv: [model, index_attrs.size, range_index_attrs.size] + index_attrs + range_index_attrs + custom_index_names,
+    )
   end
 
   sig do
@@ -118,22 +103,17 @@ class Redcord::Redis < Redis
         hash_tag: nil,
         custom_index_name: nil
       )
-    Redcord::Base.trace(
-      'redcord_redis_find_by_attr',
-      model_name: model,
-    ) do
-      conditions = flatten_with_partial_sort(query_conditions.clone, custom_index_attrs)
-      res = run_script(
-        :find_by_attr,
-        keys: [hash_tag],
-        argv: [model, custom_index_name, index_attrs.size, range_index_attrs.size, custom_index_attrs.size, conditions.size] + 
-          index_attrs + range_index_attrs + custom_index_attrs + conditions + select_attrs.to_a.flatten
-      )
-      # The Lua script will return this as a flattened array.
-      # Convert the result into a hash of {id -> model hash}
-      res_hash = res.each_slice(2)
-      res_hash.map { |key, val| [key, val.each_slice(2).to_h] }.to_h
-    end
+    conditions = flatten_with_partial_sort(query_conditions.clone, custom_index_attrs)
+    res = run_script(
+      :find_by_attr,
+      keys: [hash_tag],
+      argv: [model, custom_index_name, index_attrs.size, range_index_attrs.size, custom_index_attrs.size, conditions.size] + 
+        index_attrs + range_index_attrs + custom_index_attrs + conditions + select_attrs.to_a.flatten
+    )
+    # The Lua script will return this as a flattened array.
+    # Convert the result into a hash of {id -> model hash}
+    res_hash = res.each_slice(2)
+    res_hash.map { |key, val| [key, val.each_slice(2).to_h] }.to_h
   end
 
   sig do
@@ -156,18 +136,13 @@ class Redcord::Redis < Redis
         hash_tag: nil,
         custom_index_name: nil
       )
-    Redcord::Base.trace(
-      'redcord_redis_find_by_attr_count',
-      model_name: model,
-    ) do
-      conditions = flatten_with_partial_sort(query_conditions.clone, custom_index_attrs)
-      run_script(
-        :find_by_attr_count,
-        keys: [hash_tag],
-        argv: [model, custom_index_name, index_attrs.size, range_index_attrs.size, custom_index_attrs.size] +
-          index_attrs + range_index_attrs + custom_index_attrs + conditions
-      )
-    end
+    conditions = flatten_with_partial_sort(query_conditions.clone, custom_index_attrs)
+    run_script(
+      :find_by_attr_count,
+      keys: [hash_tag],
+      argv: [model, custom_index_name, index_attrs.size, range_index_attrs.size, custom_index_attrs.size] +
+        index_attrs + range_index_attrs + custom_index_attrs + conditions
+    )
   end
 
   def scan_each_shard(key, &blk)

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -88,16 +88,21 @@ class Redcord::Relation
 
   sig { returns(Integer) }
   def count
-    model.validate_index_attributes(query_conditions.keys, custom_index_name: custom_index_name)
-    redis.find_by_attr_count(
-      model.model_key,
-      extract_query_conditions!,
-      index_attrs: model._script_arg_index_attrs,
-      range_index_attrs: model._script_arg_range_index_attrs,
-      custom_index_attrs: model._script_arg_custom_index_attrs[custom_index_name],
-      hash_tag: extract_hash_tag!,
-      custom_index_name: custom_index_name
-    )
+    Redcord::Base.trace(
+     'redcord_relation_count',
+     model_name: model.name,
+    ) do
+      model.validate_index_attributes(query_conditions.keys, custom_index_name: custom_index_name)
+      redis.find_by_attr_count(
+        model.model_key,
+        extract_query_conditions!,
+        index_attrs: model._script_arg_index_attrs,
+        range_index_attrs: model._script_arg_range_index_attrs,
+        custom_index_attrs: model._script_arg_custom_index_attrs[custom_index_name],
+        hash_tag: extract_hash_tag!,
+        custom_index_name: custom_index_name
+      )
+    end
   end
 
   sig { params(index_name: T.nilable(Symbol)).returns(Redcord::Relation) }


### PR DESCRIPTION
Currently, the resource tag for create_hash_returning_id looks like `Redcord:ModelName` which is affecting the grouping on other resources. This fixes the issue by only tracing at actions/relation level