### PR TITLE
[feature] Custom scan_each_shard batch size

### DIFF
--- a/lib/redcord/redis.rb
+++ b/lib/redcord/redis.rb
@@ -145,19 +145,19 @@ class Redcord::Redis < Redis
     )
   end
 
-  def scan_each_shard(key, &blk)
+  def scan_each_shard(key, count: 1000, &blk)
     clients = instance_variable_get(:@client)
       &.instance_variable_get(:@node)
       &.instance_variable_get(:@clients)
       &.values
 
     if clients.nil?
-      scan_each(match: key, &blk)
+      scan_each(match: key, count: count, &blk)
     else
       clients.each do |client|
         cursor = 0
         loop do
-          cursor, keys = client.call([:scan, cursor, 'match', key])
+          cursor, keys = client.call([:scan, cursor, 'match', key, 'count', count])
           keys.each(&blk)
           break if cursor == "0"
         end


### PR DESCRIPTION
This allows users to decide how many keys to fetch for each scan.

According to redis, the SCAN command
> The default COUNT value is 10

This is not ideal for our use case -- we gonna end up with too many round trips. I updated the default to 1000 (the same default batch size as activerecord)

### Test Plan
- The changes are covered by spec
- ci