### PR TITLE
Add support for connection pooling in redcord

### DIFF
--- a/lib/redcord/connection_pool.rb
+++ b/lib/redcord/connection_pool.rb
@@ -11,7 +11,7 @@ class Redcord::ConnectionPool
   end
 
   # Avoid method_missing when possible for better performance
-  methods = Redcord::Redis.instance_methods(false) + Redis.instance_methods(false)
+  methods = Set.new(Redcord::Redis.instance_methods(false) + Redis.instance_methods(false))
   methods.each do |method_name|
     define_method method_name do |*args, &blk|
       @connection_pool.with do |redis|

--- a/lib/redcord/connection_pool.rb
+++ b/lib/redcord/connection_pool.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'connection_pool'
+require_relative 'redis'
+
+class Redcord::ConnectionPool
+  def initialize(pool_size:, timeout:, **client_options)
+    @connection_pool = ::ConnectionPool.new(size: pool_size, timeout: timeout) do
+      # Construct a new client every time the block gets called
+      Redcord::Redis.new(**client_options, logger: Redcord::Logger.proxy)
+    end
+  end
+
+  # Avoid method_missing when possible for better performance
+  %i(create_hash_returning_id update_hash delete_hash find_by_attr find_by_attr_count ping).each do |method_name|
+    define_method method_name do |*args, &blk|
+      @connection_pool.with do |redis|
+        redis.send(method_name, *args, &blk)
+      end
+    end
+  end
+
+  def method_missing(method_name, *args, &blk)
+    @connection_pool.with do |redis|
+      redis.send(method_name, *args, &blk)
+    end
+  end
+end

--- a/lib/redcord/connection_pool.rb
+++ b/lib/redcord/connection_pool.rb
@@ -11,7 +11,8 @@ class Redcord::ConnectionPool
   end
 
   # Avoid method_missing when possible for better performance
-  %i(create_hash_returning_id update_hash delete_hash find_by_attr find_by_attr_count ping).each do |method_name|
+  methods = Redcord::Redis.instance_methods(false) + Redis.instance_methods(false)
+  methods.each do |method_name|
     define_method method_name do |*args, &blk|
       @connection_pool.with do |redis|
         redis.send(method_name, *args, &blk)

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -248,7 +248,7 @@ class Redcord::Relation
     end
   end
 
-  sig { returns(Redcord::Redis) }
+  sig { returns(Redcord::RedisConnection::RedcordClientType) }
   def redis
     model.redis
   end

--- a/redcord.gemspec
+++ b/redcord.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 5'
   s.add_dependency 'railties', '>= 5'
   s.add_dependency 'redis', '~> 4'
+  s.add_dependency 'connection_pool', '>= 2.2.3'
   s.add_dependency 'sorbet', '>= 0.4.4704'
   s.add_dependency 'sorbet-coerce', '>= 0.2.7'
   s.add_dependency 'sorbet-runtime', '>= 0.4.4704'

--- a/spec/connection_pool_spec.rb
+++ b/spec/connection_pool_spec.rb
@@ -1,0 +1,34 @@
+
+describe Redcord::ConnectionPool do
+  let!(:klass) do
+    Class.new(T::Struct) do
+      include Redcord::Base
+
+      attribute :value, Integer
+
+      def self.name
+        'spec_model_2'
+      end
+    end
+  end
+
+  it 'delegates methods' do
+    env = Rails.env
+    allow(Redcord::Base).to receive(:configurations).and_return(
+      {
+        env => {
+          'spec_model_2' => {
+            'pool' => 5
+          },
+        },
+      },
+    )
+    klass.establish_connection
+    expect(klass.redis).to be_a(Redcord::ConnectionPool)
+    expect(klass.redis).to receive(:create_hash_returning_id).and_call_original
+    expect(klass.redis).to receive(:hgetall).and_call_original
+
+    record = klass.create!(value: 1)
+    klass.find(record.id)
+  end
+end

--- a/spec/redis_connection_spec.rb
+++ b/spec/redis_connection_spec.rb
@@ -40,6 +40,21 @@ describe Redcord::RedisConnection do
     }.to raise_error(Redis::CannotConnectError)
   end
 
+  it 'uses a connection pool if pool size is specified in configurations' do
+    allow(Rails).to receive(:env).and_return(env)
+    allow(Redcord::Base).to receive(:configurations).and_return(
+      {
+        env => {
+          'spec_model' => {
+            'pool' => 5
+          },
+        },
+      },
+    )
+    model_class.establish_connection
+    expect(model_class.redis).to be_a(Redcord::ConnectionPool)
+  end
+
   it 'establishes Redis connection' do
     expect(model_class.redis.ping).to eq 'PONG'
   end


### PR DESCRIPTION
### Summary
Add support for a connection pool Redis client if `pool` is specified in the configuration. This is intended to mimic how you can specify `pool` in the config/database.yml file, and overall the code is loosely based off of redis-memo's connection pool client: https://github.com/chanzuckerberg/redis-memo/blob/main/lib/redis_memo/connection_pool.rb

### Testing
Currently trying this out in Along to see if it solves our issues with performance when running multi-threaded.