### PR TITLE
Require ActiveSupport and Publish redcord package whenever release is cut

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -1,0 +1,21 @@
+name: Create and publish the Redcord package
+on:
+  release:
+    types: [published]
+jobs:
+  publish-gem:
+    runs-on: ubuntu-latest
+    env: 
+      GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+      RUBYGEMS_API_KEY: "${{secrets.RUBYGEMS_API_KEY}}"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - uses: actions/download-artifact@master
+        with:
+          name: redcord 
+      - name: Publish gems to package repositry
+        run: |
+          ./bin/publish-gem.sh

--- a/bin/publish-gem.sh
+++ b/bin/publish-gem.sh
@@ -1,0 +1,8 @@
+mkdir -p ~/.gem
+touch ~/.gem/credentials
+chmod 600 ~/.gem/credentials
+echo "---" >> ~/.gem/credentials
+echo ":github: Bearer ${GITHUB_TOKEN}" >> ~/.gem/credentials
+echo ":rubygems_api_key: ${RUBYGEMS_API_KEY}" >> ~/.gem/credentials
+ls -l 
+gem push redcord*.gem

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -2,6 +2,7 @@
 
 # typed: strict
 
+require 'active_support'
 require 'active_support/core_ext/array'
 require 'active_support/core_ext/module'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'simplecov'
 require 'open3'
+require "active_support"
 require 'active_support/time'
 
 SimpleCov.start


### PR DESCRIPTION
Known issue where in Activesupport 7.0 you can't require subcomponents w/o first requiring ActiveSupport. This should fix it 
https://github.com/rails/rails/issues/43908

Also, Heavily borrowing from https://github.com/chanzuckerberg/SSRFs-Up/blob/main/.github/workflows/build-publish.yaml#L23-L42

Added secrets to repo