### PR TITLE
[publish gem] Build the gemspec, get rid of artifacts thing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/download-artifact@master
-        with:
-          name: redcord 
       - name: Publish gems to package repositry
         run: |
           ./bin/publish-gem.sh

--- a/bin/publish-gem.sh
+++ b/bin/publish-gem.sh
@@ -4,5 +4,5 @@ chmod 600 ~/.gem/credentials
 echo "---" >> ~/.gem/credentials
 echo ":github: Bearer ${GITHUB_TOKEN}" >> ~/.gem/credentials
 echo ":rubygems_api_key: ${RUBYGEMS_API_KEY}" >> ~/.gem/credentials
-ls -l 
-gem push redcord*.gem
+gem build *.gemspec
+gem push *.gem


### PR DESCRIPTION
Trying to automatically publish gem but failing 

https://github.com/chanzuckerberg/redcord/actions/runs/1826850820

This should help 

So for background, redcord is an ORM we use in Traject.
It's published via github releases and then published to Rubygems.
Orgs using it will then pick up the update from rubygems
Usually this process happens manually.
But it's pretty easy to automate using CI. So this is adding a github action to publish a rubygem every time a release is cut in github.
I already had an attempt at this [here](https://github.com/chanzuckerberg/redcord/pull/92)
But my syntax wasn't exactly right