### PR TITLE
Gotta bump the version in the gemspec

### DIFF
--- a/redcord.gemspec
+++ b/redcord.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'redcord'
-  s.version       = '0.1.3'
+  s.version       = '0.1.4'
   s.date          = '2020-06-01'
   s.summary       = 'A Ruby ORM like Active Record, but for Redis'
   s.authors       = ['Chan Zuckerberg Initiative']


### PR DESCRIPTION
Gems are failing to build because they don't have a version in the gemspec that plays well.

Gotta bump the version in order to cut a new release I suppose ¯\_(ツ)_/¯

https://github.com/chanzuckerberg/redcord/runs/5208848654?check_suite_focus=true