### PR TITLE
Fix nil custom index attributes

### DIFF
--- a/lib/redcord/attribute.rb
+++ b/lib/redcord/attribute.rb
@@ -37,7 +37,7 @@ module Redcord::Attribute
     klass.include(InstanceMethods)
     klass.class_variable_set(:@@index_attributes, Set.new)
     klass.class_variable_set(:@@range_index_attributes, Set.new)
-    klass.class_variable_set(:@@custom_index_attributes, Hash.new { |h, k| h[k] = [] })
+    klass.class_variable_set(:@@custom_index_attributes, Hash.new)
     klass.class_variable_set(:@@ttl, nil)
     klass.class_variable_set(:@@shard_by_attribute, nil)
   end

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -99,7 +99,7 @@ class Redcord::Relation
         extract_query_conditions!,
         index_attrs: model._script_arg_index_attrs,
         range_index_attrs: model._script_arg_range_index_attrs,
-        custom_index_attrs: model._script_arg_custom_index_attrs[custom_index_name],
+        custom_index_attrs: model._script_arg_custom_index_attrs[custom_index_name] || [],
         hash_tag: extract_hash_tag!,
         custom_index_name: custom_index_name
       )
@@ -223,7 +223,7 @@ class Redcord::Relation
           select_attrs: select_attrs,
           index_attrs: model._script_arg_index_attrs,
           range_index_attrs: model._script_arg_range_index_attrs,
-          custom_index_attrs: model._script_arg_custom_index_attrs[custom_index_name],
+          custom_index_attrs: model._script_arg_custom_index_attrs[custom_index_name] || [],
           hash_tag: extract_hash_tag!,
           custom_index_name: custom_index_name
         )
@@ -239,7 +239,7 @@ class Redcord::Relation
           extract_query_conditions!,
           index_attrs: model._script_arg_index_attrs,
           range_index_attrs: model._script_arg_range_index_attrs,
-          custom_index_attrs: model._script_arg_custom_index_attrs[custom_index_name],
+          custom_index_attrs: model._script_arg_custom_index_attrs[custom_index_name] || [],
           hash_tag: extract_hash_tag!,
           custom_index_name: custom_index_name
         )

--- a/lib/redcord/serializer.rb
+++ b/lib/redcord/serializer.rb
@@ -81,7 +81,7 @@ module Redcord::Serializer
       attr_keys.each do |attr_key|
         next if attr_key == shard_by_attribute
 
-        if !custom_index_attributes.empty?
+        if !custom_index_attributes.nil? && !custom_index_attributes.empty?
           if !custom_index_attributes.include?(attr_key)
             raise(
               Redcord::AttributeNotIndexed,


### PR DESCRIPTION
### Summary
Fix nil custom index attribute class variable.

By setting the class variable [here](https://github.com/chanzuckerberg/redcord/blob/65d737da3b93147c5d29e1fda5c03f8e1bfd9ee8/lib/redcord/attribute.rb#L40), anytime a key is not found, it automatically sets the value to an empty array. See https://stackoverflow.com/questions/40795510/when-is-a-block-or-object-that-is-passed-to-hash-new-created-or-run

It makes more sense to not modify this class variable outside of setting custom index attributes [here](https://github.com/chanzuckerberg/redcord/blob/65d737da3b93147c5d29e1fda5c03f8e1bfd9ee8/lib/redcord/attribute.rb#L73)

```ruby
klass.class_variable_set(:@@custom_index_attributes, Hash.new { |h, k| h[k] = [] })
```

SoftError typeError in Vacuum Redcord [sc-185690]

### Test Plan
Specs succeed