### PR TITLE
Raise separate error when Redcord is deleted during update

### DIFF
--- a/lib/redcord.rb
+++ b/lib/redcord.rb
@@ -32,6 +32,7 @@ module Redcord
 end
 
 require 'redcord/base'
+require 'redcord/errors'
 require 'redcord/migration'
 require 'redcord/migration/migrator'
 require 'redcord/migration/version'

--- a/lib/redcord/actions.rb
+++ b/lib/redcord/actions.rb
@@ -6,12 +6,6 @@ require 'sorbet-coerce'
 
 require 'redcord/relation'
 
-module Redcord
-  # Raised by Model.find
-  class RecordNotFound < StandardError; end
-  class InvalidAction < StandardError; end
-end
-
 module Redcord::Actions
   extend T::Sig
   extend T::Helpers

--- a/lib/redcord/actions.rb
+++ b/lib/redcord/actions.rb
@@ -3,7 +3,6 @@
 # typed: strict
 
 require 'sorbet-coerce'
-
 require 'redcord/relation'
 
 module Redcord::Actions
@@ -165,6 +164,13 @@ module Redcord::Actions
           )
         end
       end
+    # TODO: break down Redis::CommandError further by parsing the error message
+    rescue Redis::CommandError => e
+      if e.message.include?('has been deleted')
+        raise Redcord::RedcordDeletedError.new(e)
+      else
+        raise e
+      end
     end
 
     sig { returns(T::Boolean) }
@@ -173,7 +179,6 @@ module Redcord::Actions
 
       true
     rescue Redis::CommandError
-      # TODO: break down Redis::CommandError by parsing the error message
       false
     end
 
@@ -207,6 +212,13 @@ module Redcord::Actions
           )
         end
       end
+    # TODO: break down Redis::CommandError further by parsing the error message
+    rescue Redis::CommandError => e
+      if e.message.include?('has been deleted')
+        raise Redcord::RedcordDeletedError.new(e)
+      else
+        raise e
+      end
     end
 
     sig { params(args: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
@@ -215,7 +227,6 @@ module Redcord::Actions
 
       true
     rescue Redis::CommandError
-      # TODO: break down Redis::CommandError by parsing the error message
       false
     end
 

--- a/lib/redcord/attribute.rb
+++ b/lib/redcord/attribute.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 # typed: strict
-module Redcord
-  class InvalidAttribute < StandardError; end
-end
 
 module Redcord::Attribute
   extend T::Sig

--- a/lib/redcord/errors.rb
+++ b/lib/redcord/errors.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'redcord/errors'
-
 module Redcord
   # Raised by Model.find
   class RecordNotFound < StandardError; end

--- a/lib/redcord/errors.rb
+++ b/lib/redcord/errors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'redcord/errors'
+
 module Redcord
   # Raised by Model.find
   class RecordNotFound < StandardError; end
@@ -11,6 +13,7 @@ module Redcord
   class WrongAttributeType < TypeError; end
   class CustomIndexInvalidQuery < StandardError; end
   class CustomIndexInvalidDesign < StandardError; end
+  class RedcordDeletedError < ::Redis::CommandError; end
 
   # Raised by shared_by_attribute
   class InvalidAttribute < StandardError; end

--- a/lib/redcord/errors.rb
+++ b/lib/redcord/errors.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Redcord
+  # Raised by Model.find
+  class RecordNotFound < StandardError; end
+  class InvalidAction < StandardError; end
+
+  # Raised by Model.where
+  class InvalidQuery < StandardError; end
+  class AttributeNotIndexed < StandardError; end
+  class WrongAttributeType < TypeError; end
+  class CustomIndexInvalidQuery < StandardError; end
+  class CustomIndexInvalidDesign < StandardError; end
+
+  # Raised by shared_by_attribute
+  class InvalidAttribute < StandardError; end
+end

--- a/lib/redcord/relation.rb
+++ b/lib/redcord/relation.rb
@@ -6,10 +6,6 @@ require 'active_support'
 require 'active_support/core_ext/array'
 require 'active_support/core_ext/module'
 
-module Redcord
-  class InvalidQuery < StandardError; end
-end
-
 class Redcord::Relation
   extend T::Sig
 

--- a/lib/redcord/serializer.rb
+++ b/lib/redcord/serializer.rb
@@ -4,14 +4,6 @@
 
 require 'redcord/range_interval'
 
-module Redcord
-  # Raised by Model.where
-  class AttributeNotIndexed < StandardError; end
-  class WrongAttributeType < TypeError; end
-  class CustomIndexInvalidQuery < StandardError; end
-  class CustomIndexInvalidDesign < StandardError; end
-end
-
 # This module defines various helper methods on Redcord for serialization
 # between the  Ruby client and Redis server.
 module Redcord::Serializer

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -327,12 +327,12 @@ describe Redcord::Actions do
 
       expect {
         instance.save!
-      }.to raise_error(Redis::CommandError)
+      }.to raise_error(Redcord::RedcordDeletedError)
       expect(klass.count).to eq 0
 
       expect {
         instance.update!(value: 2)
-      }.to raise_error(Redis::CommandError)
+      }.to raise_error(Redcord::RedcordDeletedError)
       expect(klass.count).to eq 0
     end
 


### PR DESCRIPTION
### Summary
- Move all errors to separate file
- Improve error handling parsing the error message from Redis/Lua and raising a separate error, RedcordDeletedError. This is often raised transiently when a Redcord being updated may have been deleted from another thread

### Test Plan
Updated specs to reflect new change