### PR TITLE
Changes redcord errors to subclass `RedcordError` < `StandardError`

### DIFF
--- a/lib/redcord/errors.rb
+++ b/lib/redcord/errors.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 module Redcord
+  class RedcordError < StandardError; end
+
   # Raised by Model.find
-  class RecordNotFound < StandardError; end
-  class InvalidAction < StandardError; end
+  class RecordNotFound < RedcordError; end
+  class InvalidAction < RedcordError; end
 
   # Raised by Model.where
-  class InvalidQuery < StandardError; end
-  class AttributeNotIndexed < StandardError; end
+  class InvalidQuery < RedcordError; end
+  class AttributeNotIndexed < RedcordError; end
   class WrongAttributeType < TypeError; end
-  class CustomIndexInvalidQuery < StandardError; end
-  class CustomIndexInvalidDesign < StandardError; end
+  class CustomIndexInvalidQuery < RedcordError; end
+  class CustomIndexInvalidDesign < RedcordError; end
   class RedcordDeletedError < ::Redis::CommandError; end
 
   # Raised by shared_by_attribute
-  class InvalidAttribute < StandardError; end
+  class InvalidAttribute < RedcordError; end
 end


### PR DESCRIPTION
A light-touch PR to change all Redcord errors that subclass `StandardError` to instead subclass `RecordError`, which is a `StandardError` subclass. Not sure if I'm missing other desired functionality.

Closes #100.

*Note:* I'm a new intern generally onboarding to the team! No rush on review and any/all feedback is appreciated!