### PR TITLE
Replaces deprecated `codecov` gem with GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rspec
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: coverage/coverage.xml

--- a/redcord.gemspec
+++ b/redcord.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sorbet-runtime', '>= 0.4.4704'
   s.add_dependency 'sorbet-static', '>= 0.4.4704'
 
-  s.add_development_dependency 'codecov'
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'simplecov-cobertura'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,8 @@ require 'active_support/time'
 SimpleCov.start
 
 if ENV['CI'] == 'true'
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 
 def cluster_mode?


### PR DESCRIPTION
This PR:

- removes `codecov` from the gemspec, `spec_helper.rb`
- adds `simplecov-cobertura` (required for XML formatting)
- uses the `codecov` action instead in `ci.yml`

Closes #105.