### PR TITLE
fix Ruby 3 keyword arg errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
         ruby: [2.7, 3.1, ruby-head]
         use_cluster: [true, false]
         include:
-          - ruby: 3.1 # TODO(mattxwang): remove this ASAP!
-            experimental: true # a hack to allow tests to fail for ruby-head, https://github.com/actions/toolkit/issues/399
           - ruby: ruby-head
             experimental: true # a hack to allow tests to fail for ruby-head, https://github.com/actions/toolkit/issues/399
 

--- a/lib/redcord/connection_pool.rb
+++ b/lib/redcord/connection_pool.rb
@@ -13,16 +13,16 @@ class Redcord::ConnectionPool
   # Avoid method_missing when possible for better performance
   methods = Set.new(Redcord::Redis.instance_methods(false) + Redis.instance_methods(false))
   methods.each do |method_name|
-    define_method method_name do |*args, &blk|
+    define_method method_name do |*args, **kwargs, &blk|
       @connection_pool.with do |redis|
-        redis.send(method_name, *args, &blk)
+        redis.send(method_name, *args, **kwargs, &blk)
       end
     end
   end
 
-  def method_missing(method_name, *args, &blk)
+  def method_missing(method_name, *args, **kwargs, &blk)
     @connection_pool.with do |redis|
-      redis.send(method_name, *args, &blk)
+      redis.send(method_name, *args, **kwargs, &blk)
     end
   end
 end

--- a/lib/redcord/migration/index.rb
+++ b/lib/redcord/migration/index.rb
@@ -48,7 +48,7 @@ module Redcord::Migration::Index
   sig { params(model: T.class_of(Redcord::Base), key: String).void }
   def _del_zset(model, key)
     # ZPOPMIN might not be avaliable on old redis servers
-    model.redis.zscan_each(nil, match: key) do |id, _|
+    model.redis.zscan_each(key) do |id, _|
       model.redis.zrem(key, id)
     end
 

--- a/lib/redcord/migration/index.rb
+++ b/lib/redcord/migration/index.rb
@@ -48,7 +48,7 @@ module Redcord::Migration::Index
   sig { params(model: T.class_of(Redcord::Base), key: String).void }
   def _del_zset(model, key)
     # ZPOPMIN might not be avaliable on old redis servers
-    model.redis.zscan_each(key, match: key) do |id, _|
+    model.redis.zscan_each(nil, match: key) do |id, _|
       model.redis.zrem(key, id)
     end
 

--- a/lib/redcord/migration/index.rb
+++ b/lib/redcord/migration/index.rb
@@ -48,7 +48,7 @@ module Redcord::Migration::Index
   sig { params(model: T.class_of(Redcord::Base), key: String).void }
   def _del_zset(model, key)
     # ZPOPMIN might not be avaliable on old redis servers
-    model.redis.zscan_each(match: key) do |id, _|
+    model.redis.zscan_each(key, match: key) do |id, _|
       model.redis.zrem(key, id)
     end
 


### PR DESCRIPTION
Overall, this PR resolves issues that *break tests* on Ruby 3. It's a different question on whether or not these actually bring us to Ruby 3 usability.

To test this, I think we should probably link in `redcord` to `traject` locally, and run some tests. I'm not sure if this is sufficient (or how confident we are in the test coverage in general).

Even though these two changes are one-liners, I do want to enumerate my reasoning - and apprehension - for both.

### `.send` and `define_method`

This one was trickier to hunt down, since I was confused where this call was coming from; the deprecation warning indicates that it's from sorbet, but it's actually a call validation layer in-between `redis.send`.

The core issue is explained in the "Handling argument delegation" of [the official post](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/); the tl;dr is

```ruby
# Ruby 2.6, works
# Ruby 2.7, deprecation warning
# Ruby 3, ArgumentError
def foo(*args, &block)
  target(*args, &block)
end

# Ruby 2.5, 2.6: seems to have a problem
# Ruby 2, may require `Module#ruby2_keywords`
# Ruby 3, works
def foo(*args, **kwargs, &block)
  target(*args, **kwargs, &block)
end
```

In `connection_pool`, we iterate through instance method; one of them is `create_hash_returning_id`:

```ruby
redis.send(:create_hash_returning_id, *args, &blk) 
# ~ redis.create_hash_returning_id(*args, &blk)
```

`create_hash_returning_id` takes a mix of both positional and keyword args. Thus, the new behaviour (which separates them) won't work, we'll instead need to do

```ruby
redis.send(:create_hash_returning_id, *args, **kwargs, &blk)
# ~ redis.create_hash_returning_id(*args, **kwargs, &blk)
```

So, this PR does that. 

It's a bit unclear to me on whether or not I should also update `method_missing` and `define_method`, though my intuitive understanding of this is that we should. Would love a double-check here.

(under the hood - this should resolve other sorbet call-validator errors we get, like the ones we saw in Along)

### `zscan_each`

This is a more straightforward example. I'm more curious about the behaviour we want, and in particular, why the `key` parameter was `nil` before (was it?)! And, should we be setting the `key` value to `key` instead?

Anyways, explicitly setting the positional argument as `nil` forces the keyword argument to be interpreted as a keyword. I think this is one of the edge case-like issues they discuss in the "Why we're deprecating the automatic conversion" section [of the release blog post](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).
