### PR TITLE
ci: run on 3.1, ruby-head (allowing failures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7, 3.1, ruby-head]
         use_cluster: [true, false]
+        include:
+          - ruby: 3.1 # TODO(mattxwang): remove this ASAP!
+            experimental: true # a hack to allow tests to fail for ruby-head, https://github.com/actions/toolkit/issues/399
+          - ruby: ruby-head
+            experimental: true # a hack to allow tests to fail for ruby-head, https://github.com/actions/toolkit/issues/399
 
     env:
       REDCORD_SPEC_USE_CLUSTER: ${{ matrix.use_cluster }}
@@ -37,7 +42,8 @@ jobs:
         bundler-cache: true
     - name: Sorbet Typecheck (allowed to fail)
       run: bundle exec srb tc | true
-    - run: bundle exec rspec
+    - name: "Run Tests (allowed failure: ${{ matrix.experimental == true }})"
+      run: bundle exec rspec || ${{ matrix.experimental == true }} # the eq forces a boolean instead of an empty string
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ruby: [2.5, 2.6, 2.7, 3.1, ruby-head]
         use_cluster: [true, false]


### PR DESCRIPTION
Going to start truly supporting Ruby 3, and that starts from running in on CI; uses a hack to allow the CI to fail.

I plan on removing the 3.1 check as soon as possible!