### PR TITLE
sets minimum ruby version to 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.1, ruby-head]
+        ruby: [2.7, 3.1, ruby-head]
         use_cluster: [true, false]
         include:
           - ruby: 3.1 # TODO(mattxwang): remove this ASAP!

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,2 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7

--- a/redcord.gemspec
+++ b/redcord.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.files         = Dir.glob('lib/**/*')
 
-  s.required_ruby_version = ['>= 2.5.0']
+  s.required_ruby_version = ['>= 2.7.0']
 
   s.add_dependency 'activesupport', '>= 5'
   s.add_dependency 'railties', '>= 5'


### PR DESCRIPTION
Since 2.5, 2.6 have been EOL for a while - this PR removes them out of the officially supported range.