### PR TITLE
Use `aliases:true` for `YAML.load` in Psych for Ruby version >= `3.1.0`

### DIFF
--- a/lib/redcord/railtie.rb
+++ b/lib/redcord/railtie.rb
@@ -24,9 +24,16 @@ class Redcord::Railtie < Rails::Railtie
     config_file = 'config/redcord.yml'
 
     if File.file?(config_file)
-      Redcord::Base.configurations = YAML.load(
-        ERB.new(File.read(config_file)).result
-      )
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1.0')
+        Redcord::Base.configurations = YAML.load(
+          ERB.new(File.read(config_file)).result,
+        )
+      else
+        Redcord::Base.configurations = YAML.load(
+          ERB.new(File.read(config_file)).result,
+          aliases: true,
+        )
+      end
     end
 
     Redcord._after_initialize!


### PR DESCRIPTION
This PR makes redcord work properly with the version of psych bundled with Ruby versions >= `3.1.0`.

Quick summary:

- in Ruby 3.1, psych (the bundled YAML parser) has a major version bump to 4
- a breaking change is the behaviour of psych's `load_file`, which `YAML.load` wraps:
    - previously (Psych < 4), `load_file` is "unsafe" by default: this includes parsing aliases
    - in Psych > 4, `load_file` is safe by default; users need to opt in to alias parsing (and other extended YAML features)
- however, simply using `aliases: true` breaks on Psych < 4, since the keyword doesn't exist for earlier versions of psych (and throws an error)
- therefore, this PR:
    - uses the Ruby version as a heuristic for the bundled psych version
    - on Ruby versions >= `3.1.0`, explicitly passes in `aliases: true`
    - otherwise, keeps the same behaviour as before

In particular, this should let us support Ruby 3.1 without cutting support for Ruby < 3.1 (i.e., in traject). 

## Test Plan

Stephen and I deployed this version of redcord to Along (see: https://github.com/chanzuckerberg/along/pull/5058), and confirmed it resolves the previous issue.