### PR TITLE
Fix trace signature to accept tags as a hash instead of an array

### DIFF
--- a/lib/redcord/tracer.rb
+++ b/lib/redcord/tracer.rb
@@ -22,7 +22,7 @@ module Redcord::Tracer
       params(
         span_name: String,
         model_name: String,
-        tags: T::Hash[T.any(Symbol, String), String],
+        tags: T::Hash[String, String],
         blk: T.proc.returns(T.untyped),
       ).returns(T.untyped)
     }

--- a/lib/redcord/tracer.rb
+++ b/lib/redcord/tracer.rb
@@ -22,11 +22,11 @@ module Redcord::Tracer
       params(
         span_name: String,
         model_name: String,
-        tags: T::Array[String],
+        tags: T::Hash[T.any(Symbol, String), String],
         blk: T.proc.returns(T.untyped),
       ).returns(T.untyped)
     }
-    def trace(span_name, model_name:, tags: [], &blk)
+    def trace(span_name, model_name:, tags: {}, &blk)
       return blk.call if @@tracer.nil?
 
       @@tracer.call.trace(

--- a/spec/tracer_spec.rb
+++ b/spec/tracer_spec.rb
@@ -18,8 +18,12 @@ describe Redcord::Tracer do
       counter = 0
 
       expect(
-        trace('test', model_name: 'test') { counter += 1 }
+        trace('test', model_name: 'test', tags: {
+                'env' => 'tag_env',
+                'version' => 'tag_version'
+              }) { counter += 1 }
       ).to be 1
+
       expect(counter).to be 1
     end
   end
@@ -32,7 +36,10 @@ describe Redcord::Tracer do
     it 'does not record traces' do
       counter = 0
       expect(
-        trace('test', model_name: 'test') { counter += 2 }
+        trace('test', model_name: 'test', tags: {
+                'env' => 'tag_env',
+                'version' => 'tag_version'
+              }) { counter += 2 }
       ).to be 2
       expect(counter).to be 2
     end

--- a/spec/tracer_spec.rb
+++ b/spec/tracer_spec.rb
@@ -23,7 +23,6 @@ describe Redcord::Tracer do
                 'version' => 'tag_version'
               }) { counter += 1 }
       ).to be 1
-
       expect(counter).to be 1
     end
   end


### PR DESCRIPTION
The main tracer example, ddtrace, uses a hash for tags in both 0.x and 1.x

0.54: https://github.com/DataDog/dd-trace-rb/blob/v0.54.2/spec/ddtrace/tracer_spec.rb
1.x: https://s3.amazonaws.com/gems.datadoghq.com/trace/docs/Datadog/Tracing.html#trace-class_method

The industry is moving toward the OpenTelemetry standard so we could do that too. I think ddtrace's upgrade to 1.0 already implements a lot of those interfaces.